### PR TITLE
Bump go-ibft module to apply consensus halt fix

### DIFF
--- a/consensus/ibft/consensus_backend.go
+++ b/consensus/ibft/consensus_backend.go
@@ -140,6 +140,11 @@ func (i *backendIBFT) MaximumFaultyNodes() uint64 {
 	return uint64(CalcMaxFaultyNodes(i.currentValidators))
 }
 
+// StartRound starts a new round with the given view
+func (i *backendIBFT) StartRound(view *proto.View) error {
+	return nil
+}
+
 // DISCLAIMER: IBFT will be deprecated so we set 1 as a voting power to all validators
 func (i *backendIBFT) GetVotingPowers(height uint64) (map[string]*big.Int, error) {
 	validators, err := i.forkManager.GetValidators(height)

--- a/consensus/polybft/consensus_runtime.go
+++ b/consensus/polybft/consensus_runtime.go
@@ -769,6 +769,11 @@ func (c *consensusRuntime) InsertProposal(proposal *proto.Proposal, committedSea
 	c.OnBlockInserted(fullBlock)
 }
 
+// StartRound starts a new round with the given view
+func (c *consensusRuntime) StartRound(view *proto.View) error {
+	return nil
+}
+
 // ID return ID (address actually) of the current node
 func (c *consensusRuntime) ID() []byte {
 	return c.config.Key.Address().Bytes()

--- a/go.mod
+++ b/go.mod
@@ -58,7 +58,7 @@ require (
 )
 
 require (
-	github.com/0xPolygon/go-ibft v0.4.1-0.20230717081138-628065cf23b6
+	github.com/0xPolygon/go-ibft v0.4.1-0.20240424093031-00f7637226a6
 	github.com/docker/docker v24.0.6+incompatible
 	github.com/docker/go-connections v0.4.0
 	go.etcd.io/bbolt v1.3.7

--- a/go.sum
+++ b/go.sum
@@ -18,8 +18,8 @@ dmitri.shuralyov.com/state v0.0.0-20180228185332-28bcc343414c/go.mod h1:0PRwlb0D
 filippo.io/edwards25519 v1.0.0-rc.1 h1:m0VOOB23frXZvAOK44usCgLWvtsxIoMCTBGJZlpmGfU=
 filippo.io/edwards25519 v1.0.0-rc.1/go.mod h1:N1IkdkCkiLB6tki+MYJoSx2JTY9NUlxZE7eHn5EwJns=
 git.apache.org/thrift.git v0.0.0-20180902110319-2566ecd5d999/go.mod h1:fPE2ZNJGynbRyZ4dJvy6G277gSllfV2HJqblrnkyeyg=
-github.com/0xPolygon/go-ibft v0.4.1-0.20230717081138-628065cf23b6 h1:EL/37sEjeLmQ2RTd9xMLLOuMXY6fMV/zB8a5X0BJUMM=
-github.com/0xPolygon/go-ibft v0.4.1-0.20230717081138-628065cf23b6/go.mod h1:0W1BnkhtXa2K59PzTPoQvbKOnI+G6QliXIHpQWNeiAM=
+github.com/0xPolygon/go-ibft v0.4.1-0.20240424093031-00f7637226a6 h1:s8YmD/yvpC2Lu3vSrb0laBThj/YCnQ1dpnVZqf4CfHo=
+github.com/0xPolygon/go-ibft v0.4.1-0.20240424093031-00f7637226a6/go.mod h1:FPdz+s0jyQzW4pZK+HMnhz2b8ebsg5FaSVFTjvQi8ls=
 github.com/Azure/go-ansiterm v0.0.0-20210617225240-d185dfc1b5a1 h1:UQHMgLO+TxOElx5B5HZ4hJQsoJ/PvUvKRhJHDQXO8P8=
 github.com/Azure/go-ansiterm v0.0.0-20210617225240-d185dfc1b5a1/go.mod h1:xomTg63KZ2rFqZQzSB4Vz2SUXa1BpHTVz9L5PTmPC4E=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=


### PR DESCRIPTION
# Description

Upgrade go-ibft (core consensus library) to apply a fix that causes a halt in the chain from time to time.
Integrate the startRound method introduced in go-ibft.

# Changes include

- [ ] Bugfix (non-breaking change that solves an issue)
- [x] Hotfix (change that solves an urgent issue, and requires immediate attention)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)
