### PR TITLE
set commission command

### DIFF
--- a/README.md
+++ b/README.md
@@ -188,6 +188,15 @@ hydra hydragon stake --data-dir ./node-secrets --self true --amount 990000000000
 
 Congratulations! You have successfully become a validator on the Hydra Chain. For further information and support, join our Telegram group and engage with the community.
 
+### Set or update the commission for the delegators
+
+After becoming a validator, you can set the desired commission that will be deducted from the delegators' rewards.
+Additionally, you can update the commission if you need to.
+
+```
+hydra hydragon commission --data-dir ./node-secrets --commission 10 --jsonrpc http://localhost:8545
+```
+
 ### Command Line Interface
 
 Here are the HydraChain node CLI commands that currently can be used:
@@ -195,7 +204,7 @@ Here are the HydraChain node CLI commands that currently can be used:
 - Usage:
 
 ```
-    hydra [command]
+  hydra [command]
 ```
 
 - Available Commands:

--- a/command/polybft/polybft_command.go
+++ b/command/polybft/polybft_command.go
@@ -7,6 +7,7 @@ import (
 	"github.com/0xPolygon/polygon-edge/command/sidechain/staking"
 	"github.com/0xPolygon/polygon-edge/command/sidechain/whitelist"
 
+	"github.com/0xPolygon/polygon-edge/command/sidechain/commission"
 	"github.com/0xPolygon/polygon-edge/command/sidechain/rewards"
 	"github.com/0xPolygon/polygon-edge/command/sidechain/unstaking"
 	sidechainWithdraw "github.com/0xPolygon/polygon-edge/command/sidechain/withdraw"
@@ -33,6 +34,8 @@ func GetCommand() *cobra.Command {
 		registration.GetCommand(),
 		// sidechain (validator set) command to whitelist validators
 		whitelist.GetCommand(),
+		// sidechain (hydra delegation) command to set commission
+		commission.GetCommand(),
 	)
 
 	return polybftCmd

--- a/command/sidechain/commission/commission.go
+++ b/command/sidechain/commission/commission.go
@@ -1,0 +1,165 @@
+package commission
+
+import (
+	"errors"
+	"fmt"
+	"math/big"
+	"time"
+
+	"github.com/0xPolygon/polygon-edge/command"
+	"github.com/0xPolygon/polygon-edge/command/helper"
+	"github.com/0xPolygon/polygon-edge/command/polybftsecrets"
+	"github.com/0xPolygon/polygon-edge/command/sidechain"
+	"github.com/0xPolygon/polygon-edge/consensus/polybft/contractsapi"
+	"github.com/0xPolygon/polygon-edge/consensus/polybft/wallet"
+	"github.com/0xPolygon/polygon-edge/contracts"
+	"github.com/0xPolygon/polygon-edge/txrelayer"
+	"github.com/0xPolygon/polygon-edge/types"
+	"github.com/spf13/cobra"
+	"github.com/umbracle/ethgo"
+)
+
+var (
+	delegationManager         = contracts.HydraDelegationContract
+	commissionUpdatedEventABI = contractsapi.HydraDelegation.Abi.Events["CommissionUpdated"]
+)
+
+var params setCommissionParams
+
+func GetCommand() *cobra.Command {
+	setCommissionCmd := &cobra.Command{
+		Use:     "commission",
+		Short:   "Set a commission for a validator (staker)",
+		PreRunE: runPreRun,
+		RunE:    runCommand,
+	}
+
+	setFlags(setCommissionCmd)
+	helper.SetRequiredFlags(setCommissionCmd, params.getRequiredFlags())
+
+	return setCommissionCmd
+}
+
+func setFlags(cmd *cobra.Command) {
+	cmd.Flags().StringVar(
+		&params.accountDir,
+		polybftsecrets.AccountDirFlag,
+		"",
+		polybftsecrets.AccountDirFlagDesc,
+	)
+
+	cmd.Flags().StringVar(
+		&params.accountConfig,
+		polybftsecrets.AccountConfigFlag,
+		"",
+		polybftsecrets.AccountConfigFlagDesc,
+	)
+
+	cmd.Flags().Uint64Var(
+		&params.commission,
+		commissionFlag,
+		0,
+		"mandatory flag that represents the commission percentage of the validator (staker)",
+	)
+
+	cmd.Flags().BoolVar(
+		&params.insecureLocalStore,
+		sidechain.InsecureLocalStoreFlag,
+		false,
+		"a flag to indicate if the secrets used are encrypted. If set to true, the secrets are stored in plain text.",
+	)
+
+	helper.RegisterJSONRPCFlag(cmd)
+
+	cmd.MarkFlagsMutuallyExclusive(polybftsecrets.AccountConfigFlag, polybftsecrets.AccountDirFlag)
+}
+
+func runPreRun(cmd *cobra.Command, _ []string) error {
+	params.jsonRPC = helper.GetJSONRPCAddress(cmd)
+
+	return params.validateFlags()
+}
+
+func runCommand(cmd *cobra.Command, _ []string) error {
+	outputter := command.InitializeOutputter(cmd)
+	defer outputter.WriteOutput()
+
+	secretsManager, err := polybftsecrets.GetSecretsManager(
+		params.accountDir,
+		params.accountConfig,
+		params.insecureLocalStore,
+	)
+	if err != nil {
+		return err
+	}
+
+	txRelayer, err := txrelayer.NewTxRelayer(
+		txrelayer.WithIPAddress(params.jsonRPC),
+		txrelayer.WithReceiptTimeout(150*time.Millisecond),
+	)
+	if err != nil {
+		return err
+	}
+
+	validatorAccount, err := wallet.NewAccountFromSecret(secretsManager)
+	if err != nil {
+		return err
+	}
+
+	receipt, err := setCommission(txRelayer, validatorAccount)
+	if err != nil {
+		return err
+	}
+
+	if receipt.Status != uint64(types.ReceiptSuccess) {
+		return errors.New("register validator transaction failed")
+	}
+
+	result := &setCommissionResult{}
+	foundCommissionUpdatedLog := false
+
+	for _, log := range receipt.Logs {
+		if commissionUpdatedEventABI.Match(log) {
+			event, err := commissionUpdatedEventABI.ParseLog(log)
+			if err != nil {
+				return err
+			}
+
+			result.staker = event["staker"].(ethgo.Address).String()          //nolint:forcetypeassert
+			result.newCommission = event["newCommission"].(*big.Int).Uint64() //nolint:forcetypeassert
+			foundCommissionUpdatedLog = true
+		}
+	}
+
+	if !foundCommissionUpdatedLog {
+		return fmt.Errorf("could not find an appropriate log in the receipt that validates the new commission update")
+	}
+
+	outputter.WriteCommandResult(result)
+
+	return nil
+}
+
+func setCommission(sender txrelayer.TxRelayer, account *wallet.Account) (*ethgo.Receipt, error) {
+	setCommissionFn := &contractsapi.SetCommissionHydraDelegationFn{
+		NewCommission: new(big.Int).SetUint64(params.commission),
+	}
+
+	input, err := setCommissionFn.EncodeAbi()
+	if err != nil {
+		return nil, fmt.Errorf("encoding set commission function failed: %w", err)
+	}
+
+	txn := &ethgo.Transaction{
+		Input: input,
+		To:    (*ethgo.Address)(&delegationManager),
+	}
+
+	receipt, err := sender.SendTransaction(txn, account.Ecdsa)
+	if err != nil {
+		// retry execution. Issue: https://github.com/valyala/fasthttp/issues/189
+		receipt, err = sender.SendTransaction(txn, account.Ecdsa)
+	}
+
+	return receipt, err
+}

--- a/command/sidechain/commission/params.go
+++ b/command/sidechain/commission/params.go
@@ -1,0 +1,73 @@
+package commission
+
+import (
+	"bytes"
+	"fmt"
+
+	"github.com/0xPolygon/polygon-edge/command/helper"
+	sidechainHelper "github.com/0xPolygon/polygon-edge/command/sidechain"
+)
+
+const (
+	commissionFlag = "commission"
+)
+
+type setCommissionParams struct {
+	accountDir         string
+	accountConfig      string
+	commission         uint64
+	jsonRPC            string
+	insecureLocalStore bool
+}
+
+type setCommissionResult struct {
+	staker        string
+	newCommission uint64
+}
+
+func (scp *setCommissionParams) getRequiredFlags() []string {
+	return []string{
+		commissionFlag,
+	}
+}
+
+func (scp *setCommissionParams) validateFlags() error {
+	if err := sidechainHelper.ValidateSecretFlags(scp.accountDir, scp.accountConfig); err != nil {
+		return err
+	}
+
+	if _, err := helper.ParseJSONRPCAddress(scp.jsonRPC); err != nil {
+		return fmt.Errorf("failed to parse json rpc address. Error: %w", err)
+	}
+
+	return validateCommission(params.commission)
+}
+
+func validateCommission(commission uint64) error {
+	if commission > sidechainHelper.MaxCommission {
+		return fmt.Errorf(
+			"provided commission '%d' is higher than the maximum of '%d'",
+			commission,
+			sidechainHelper.MaxCommission,
+		)
+	}
+
+	return nil
+}
+
+func (scr setCommissionResult) GetOutput() string {
+	var buffer bytes.Buffer
+
+	var vals []string
+
+	buffer.WriteString("\n[COMMISSION SET]\n")
+
+	vals = make([]string, 0, 3)
+	vals = append(vals, fmt.Sprintf("Staker Address|%s", scr.staker))
+	vals = append(vals, fmt.Sprintf("New Commission |%v", scr.newCommission))
+
+	buffer.WriteString(helper.FormatKV(vals))
+	buffer.WriteString("\n")
+
+	return buffer.String()
+}

--- a/command/sidechain/commission/params.go
+++ b/command/sidechain/commission/params.go
@@ -40,14 +40,10 @@ func (scp *setCommissionParams) validateFlags() error {
 		return fmt.Errorf("failed to parse json rpc address. Error: %w", err)
 	}
 
-	return validateCommission(params.commission)
-}
-
-func validateCommission(commission uint64) error {
-	if commission > sidechainHelper.MaxCommission {
+	if params.commission > sidechainHelper.MaxCommission {
 		return fmt.Errorf(
 			"provided commission '%d' is higher than the maximum of '%d'",
-			commission,
+			params.commission,
 			sidechainHelper.MaxCommission,
 		)
 	}

--- a/command/sidechain/helper.go
+++ b/command/sidechain/helper.go
@@ -15,6 +15,7 @@ const (
 	InsecureLocalStoreFlag = "insecure"
 
 	DefaultGasPrice = 1879048192 // 0x70000000
+	MaxCommission   = 100
 )
 
 func CheckIfDirectoryExist(dir string) error {

--- a/command/sidechain/registration/params.go
+++ b/command/sidechain/registration/params.go
@@ -12,11 +12,6 @@ import (
 const (
 	stakeFlag   = "stake"
 	chainIDFlag = "chain-id"
-	commissionFlag = "commission"
-)
-
-const (
-	maxCommission = 100
 )
 
 type registerParams struct {
@@ -24,7 +19,6 @@ type registerParams struct {
 	accountConfig      string
 	jsonRPC            string
 	stake              string
-	commission         uint64
 	chainID            int64
 	insecureLocalStore bool
 }
@@ -45,10 +39,6 @@ func (rp *registerParams) validateFlags() error {
 		}
 	}
 
-	if (rp.commission > maxCommission) {
-		return fmt.Errorf("provided commission '%d' is higher than the maximum of '%d'", rp.commission, maxCommission)
-	}
-
 	return nil
 }
 
@@ -56,7 +46,6 @@ type registerResult struct {
 	validatorAddress string
 	stakeResult      string
 	amount           string
-	commission       uint64
 }
 
 func (rr registerResult) GetOutput() string {
@@ -70,7 +59,6 @@ func (rr registerResult) GetOutput() string {
 	vals = append(vals, fmt.Sprintf("Validator Address|%s", rr.validatorAddress))
 	vals = append(vals, fmt.Sprintf("Staking Result|%s", rr.stakeResult))
 	vals = append(vals, fmt.Sprintf("Amount Staked|%v", rr.amount))
-	vals = append(vals, fmt.Sprintf("Commission |%v", rr.commission))
 
 	buffer.WriteString(helper.FormatKV(vals))
 	buffer.WriteString("\n")

--- a/command/sidechain/registration/register_validator.go
+++ b/command/sidechain/registration/register_validator.go
@@ -84,6 +84,7 @@ func setFlags(cmd *cobra.Command) {
 	)
 
 	helper.RegisterJSONRPCFlag(cmd)
+
 	cmd.MarkFlagsMutuallyExclusive(polybftsecrets.AccountConfigFlag, polybftsecrets.AccountDirFlag)
 }
 
@@ -161,7 +162,9 @@ func runCommand(cmd *cobra.Command, _ []string) error {
 	}
 
 	if !foundNewValidatorLog {
-		return fmt.Errorf("could not find an appropriate log in the receipt that validates the registration has happened")
+		return fmt.Errorf(
+			"could not find an appropriate log in the receipt that validates the registration has happened",
+		)
 	}
 
 	if params.stake != "" {
@@ -235,8 +238,11 @@ func populateStakeResults(receipt *ethgo.Receipt, result *registerResult) {
 	result.stakeResult = "Could not find an appropriate log in receipt that stake happened"
 }
 
-func registerValidator(sender txrelayer.TxRelayer, account *wallet.Account,
-	signature *bls.Signature) (*ethgo.Receipt, error) {
+func registerValidator(
+	sender txrelayer.TxRelayer,
+	account *wallet.Account,
+	signature *bls.Signature,
+) (*ethgo.Receipt, error) {
 	sigMarshal, err := signature.ToBigInt()
 	if err != nil {
 		return nil, fmt.Errorf("register validator failed: %w", err)

--- a/consensus/polybft/contractsapi/bindings-gen/main.go
+++ b/consensus/polybft/contractsapi/bindings-gen/main.go
@@ -91,6 +91,7 @@ func main() {
 				"delegate",
 				"undelegate",
 				"claimDelegatorReward",
+				"setCommission",
 			},
 			[]string{
 				"CommissionUpdated",

--- a/consensus/polybft/contractsapi/contractsapi.go
+++ b/consensus/polybft/contractsapi/contractsapi.go
@@ -640,6 +640,22 @@ func (c *ClaimDelegatorRewardHydraDelegationFn) DecodeAbi(buf []byte) error {
 	return decodeMethod(HydraDelegation.Abi.Methods["claimDelegatorReward"], buf, c)
 }
 
+type SetCommissionHydraDelegationFn struct {
+	NewCommission *big.Int `abi:"newCommission"`
+}
+
+func (s *SetCommissionHydraDelegationFn) Sig() []byte {
+	return HydraDelegation.Abi.Methods["setCommission"].ID()
+}
+
+func (s *SetCommissionHydraDelegationFn) EncodeAbi() ([]byte, error) {
+	return HydraDelegation.Abi.Methods["setCommission"].Encode(s)
+}
+
+func (s *SetCommissionHydraDelegationFn) DecodeAbi(buf []byte) error {
+	return decodeMethod(HydraDelegation.Abi.Methods["setCommission"], buf, s)
+}
+
 type CommissionUpdatedEvent struct {
 	Staker        types.Address `abi:"staker"`
 	NewCommission *big.Int      `abi:"newCommission"`

--- a/h_docs/polybft_setup.md
+++ b/h_docs/polybft_setup.md
@@ -81,6 +81,12 @@ Stake tx is made in this step as well
 ./hydra server --data-dir ./test-add-chain-1 --chain genesis.json --grpc-address :5006 --libp2p :30306 --jsonrpc :10006 --log-level DEBUG --log-to ./log-6
 ```
 
+5. Set or update commission of the validator that will taken from the delegators' rewards.
+
+```
+./hydra hydragon commission --data-dir ./test-add-chain-1 --commission 10 --jsonrpc http://127.0.0.1:10001 --insecure
+```
+
 ### LEGACY local setup
 
 1. Generate secrets
@@ -196,6 +202,12 @@ Use the following command in case you want to execute the stake operation only:
 
 ```
 ./hydra hydragon stake --data-dir ./node --self true --amount 999900000000000000000000 --jsonrpc http://localhost:8545
+```
+
+6. Set or update your commission that will taken from the delegators' rewards.
+
+```
+./hydra hydragon commission --data-dir ./node --commission 10 --jsonrpc http://localhost:8545
 ```
 
 Congratulations! You are now a Hydra Chain validator!

--- a/h_docs/polybft_setup.md
+++ b/h_docs/polybft_setup.md
@@ -204,13 +204,14 @@ Use the following command in case you want to execute the stake operation only:
 ./hydra hydragon stake --data-dir ./node --self true --amount 999900000000000000000000 --jsonrpc http://localhost:8545
 ```
 
-6. Set or update your commission that will taken from the delegators' rewards.
+Congratulations! You are now a Hydra Chain validator!
+
+6. After becoming a validator, you can set the desired commission that will be deducted from the delegators' rewards.
+Additionally, you can update the commission if you need to.
 
 ```
 ./hydra hydragon commission --data-dir ./node --commission 10 --jsonrpc http://localhost:8545
 ```
-
-Congratulations! You are now a Hydra Chain validator!
 
 ### Admin actions for devnet node setup
 


### PR DESCRIPTION
# Description

- create a new directory and files for the set commission command;
- move the maxCommission variable in the sidechain helper;
- bind the set commission function;
- implement the functionality for the commission;
- delete the commission flag from the register_validator command;
- update the docs where needed;

# Changes include

- [x] New feature (non-breaking change that adds functionality)

# Checklist

- [x] I have added at least 1 reviewer
- [x] I have added the relevant labels
- [x] I have updated the official documentation
- [x] I have added sufficient documentation in code

## Testing

- [x] I have tested this code manually

### Manual tests

I have tested running the new CLI command w/o the required flags - it throws proper error when no flag provided and it correctly updates the commission, when provided.