### PR TITLE
60 change naming conventions of wallets as part of the setup process

### DIFF
--- a/README.md
+++ b/README.md
@@ -180,7 +180,7 @@ Hydra's validator set is unique as it offers a permissionless opportunity on a f
 After ensuring you have a minimum of 15,000 HYDRA in your validator wallet, you can execute the following command.
 
 ```
-hydra hydragon register-validator --data-dir ./node-secrets --stake 15000000000000000000000 --chain-id 8844 --jsonrpc http://localhost:8545
+hydra hydragon register-validator --data-dir ./node-secrets --stake 15000000000000000000000 --jsonrpc http://localhost:8545
 ```
 
 The above command both register the validator and stakes the specified amount.

--- a/README.md
+++ b/README.md
@@ -159,20 +159,6 @@ Once your node is operational and fully synced, you're ready to become a validat
 
 **Note:** Currently, you will have to import the validator's private key into Metamask to be able to interact with the web UI which can be considered as a security issue, but we will provide better option in the future.
 
-### Obtaining your Public Key 
-Use the following command to retrieve your public key:
-
-```
-./hydra secrets output-public --data-dir node-secrets
-```
-
-You need the following value:
-
-```
-[PUBLIC DATA OUTPUT]
-Validator Address = 0x...
-```
-
 ### Register account as validator and stake
 
 Hydra's validator set is unique as it offers a permissionless opportunity on a first come/first serve. It supports up to 150 validators and uses exponentiating formula to ensure consolidation is countered for a maximum Nakamoto Coefficient. The requirements to become a validator: a) to have a minimum of 15,000 HYDRA and b) there to be vacant slots in the validator sets. Inactive validators are going to be ejected after 72 hours in order to ensure fair environment and highest level of network security.

--- a/command/polybftsecrets/result.go
+++ b/command/polybftsecrets/result.go
@@ -39,7 +39,7 @@ func (r *SecretsInitResult) GetOutput() string {
 
 	vals = append(
 		vals,
-		fmt.Sprintf("Public key (address)|%s", r.Address.String()),
+		fmt.Sprintf("EVM Address|%s", r.Address.String()),
 	)
 
 	if r.PrivateKey != "" {
@@ -52,14 +52,14 @@ func (r *SecretsInitResult) GetOutput() string {
 	if r.BLSPrivateKey != "" {
 		vals = append(
 			vals,
-			fmt.Sprintf("BLS Private key|%s", r.BLSPrivateKey),
+			fmt.Sprintf("Validator BLS Private key|%s", r.BLSPrivateKey),
 		)
 	}
 
 	if r.BLSPubkey != "" {
 		vals = append(
 			vals,
-			fmt.Sprintf("BLS Public key|%s", r.BLSPubkey),
+			fmt.Sprintf("Validator BLS Public key|%s", r.BLSPubkey),
 		)
 	}
 

--- a/command/secrets/output-private/result.go
+++ b/command/secrets/output-private/result.go
@@ -18,9 +18,9 @@ func (r *SecretsOutputResult) GetOutput() string {
 
 	buffer.WriteString("\n[PRIVATE KEYS OUTPUT]\n")
 	buffer.WriteString(helper.FormatKV([]string{
-		fmt.Sprintf("Network Key|%s", r.NetworkKey),
-		fmt.Sprintf("Private Key|%s", r.PrivateKey),
-		fmt.Sprintf("BLS Private Key|%s", r.BLSPrivateKey),
+		fmt.Sprintf("Network Private Key|%s", r.NetworkKey),
+		fmt.Sprintf("EVM Private Key|%s", r.PrivateKey),
+		fmt.Sprintf("Validator BLS Private Key|%s", r.BLSPrivateKey),
 	}))
 
 	return buffer.String()

--- a/command/secrets/output-public/result.go
+++ b/command/secrets/output-public/result.go
@@ -18,8 +18,8 @@ func (or *OutputResult) GetOutput() string {
 
 	buffer.WriteString("\n[PUBLIC DATA OUTPUT]\n")
 	buffer.WriteString(helper.FormatKV([]string{
-		fmt.Sprintf("Validator Address|%s", or.ValidatorAddress),
-		fmt.Sprintf("BLS Public Key|%s", or.BLSPublicKey),
+		fmt.Sprintf("EVM Address|%s", or.ValidatorAddress),
+		fmt.Sprintf("Validator BLS Public Key|%s", or.BLSPublicKey),
 		fmt.Sprintf("Node ID|%s", or.NodeID),
 	}))
 

--- a/command/sidechain/registration/params.go
+++ b/command/sidechain/registration/params.go
@@ -10,8 +10,7 @@ import (
 )
 
 const (
-	stakeFlag   = "stake"
-	chainIDFlag = "chain-id"
+	stakeFlag = "stake"
 )
 
 type registerParams struct {
@@ -19,7 +18,6 @@ type registerParams struct {
 	accountConfig      string
 	jsonRPC            string
 	stake              string
-	chainID            int64
 	insecureLocalStore bool
 }
 

--- a/command/sidechain/registration/params.go
+++ b/command/sidechain/registration/params.go
@@ -53,15 +53,24 @@ func (rr registerResult) GetOutput() string {
 
 	var vals []string
 
-	buffer.WriteString("\n[REGISTRATION]\n")
+	buffer.WriteString("\n[SUCCESSFUL REGISTRATION]\n")
 
-	vals = make([]string, 0, 3)
-	vals = append(vals, fmt.Sprintf("Validator Address|%s", rr.validatorAddress))
-	vals = append(vals, fmt.Sprintf("Staking Result|%s", rr.stakeResult))
-	vals = append(vals, fmt.Sprintf("Amount Staked|%v", rr.amount))
+	vals = make([]string, 0, 1)
+	vals = append(vals, fmt.Sprintf("EVM Address|%s", rr.validatorAddress))
 
 	buffer.WriteString(helper.FormatKV(vals))
 	buffer.WriteString("\n")
+
+	if rr.stakeResult != "" {
+		buffer.WriteString("\n[SELF STAKE]\n")
+
+		vals = make([]string, 0, 2)
+		vals = append(vals, fmt.Sprintf("Staking Result|%s", rr.stakeResult))
+		vals = append(vals, fmt.Sprintf("Amount Staked|%v", rr.amount))
+
+		buffer.WriteString(helper.FormatKV(vals))
+		buffer.WriteString("\n")
+	}
 
 	return buffer.String()
 }

--- a/command/sidechain/registration/register_validator.go
+++ b/command/sidechain/registration/register_validator.go
@@ -69,13 +69,6 @@ func setFlags(cmd *cobra.Command) {
 		"stake represents amount which is going to be staked by the new validator account",
 	)
 
-	cmd.Flags().Int64Var(
-		&params.chainID,
-		chainIDFlag,
-		command.DefaultChainID,
-		"the ID of the chain",
-	)
-
 	cmd.Flags().BoolVar(
 		&params.insecureLocalStore,
 		sidechain.InsecureLocalStoreFlag,

--- a/command/sidechain/registration/register_validator.go
+++ b/command/sidechain/registration/register_validator.go
@@ -204,7 +204,7 @@ func stake(sender txrelayer.TxRelayer, account *wallet.Account) (*ethgo.Receipt,
 
 func populateStakeResults(receipt *ethgo.Receipt, result *registerResult) {
 	if receipt.Status != uint64(types.ReceiptSuccess) {
-		result.stakeResult = "Stake transaction failed"
+		result.stakeResult = fmt.Sprintf("Stake transaction failed. Tx: %s", receipt.TransactionHash.String())
 		result.amount = "0"
 
 		return

--- a/command/sidechain/registration/register_validator.go
+++ b/command/sidechain/registration/register_validator.go
@@ -155,8 +155,6 @@ func runCommand(cmd *cobra.Command, _ []string) error {
 			}
 
 			result.validatorAddress = event["validator"].(ethgo.Address).String() //nolint:forcetypeassert
-			result.stakeResult = "No stake parameters have been submitted"
-			result.amount = "0"
 			foundNewValidatorLog = true
 		}
 	}
@@ -214,6 +212,7 @@ func stake(sender txrelayer.TxRelayer, account *wallet.Account) (*ethgo.Receipt,
 func populateStakeResults(receipt *ethgo.Receipt, result *registerResult) {
 	if receipt.Status != uint64(types.ReceiptSuccess) {
 		result.stakeResult = "Stake transaction failed"
+		result.amount = "0"
 
 		return
 	}

--- a/h_docs/polybft_setup.md
+++ b/h_docs/polybft_setup.md
@@ -82,7 +82,7 @@ for the secret keys, and the following for the public keys, including the Node I
 Stake tx is made in this step as well
 
 ```
-./hydra hydragon register-validator --data-dir ./test-add-chain-1 --stake 15000000000000000000000 --chain-id 8844 --jsonrpc http://127.0.0.1:10001 --insecure
+./hydra hydragon register-validator --data-dir ./test-add-chain-1 --stake 15000000000000000000000 --jsonrpc http://127.0.0.1:10001 --insecure
 ```
 
 4. Run new validator
@@ -203,7 +203,7 @@ After Hydra's team confirms you are whitelisted you have to register your accoun
 In the container's shell execute:
 
 ```
-./hydra hydragon register-validator --data-dir ./node --stake 1000000000000000000000000 --chain-id 8844 --jsonrpc http://localhost:8545
+./hydra hydragon register-validator --data-dir ./node --stake 1000000000000000000000000 --jsonrpc http://localhost:8545
 ```
 
 The above command both register the validator and stakes the specified amount.

--- a/secrets/secrets.go
+++ b/secrets/secrets.go
@@ -24,13 +24,13 @@ const (
 // Define constant names for available secrets
 const (
 	// ValidatorKey is the private key secret of the validator node
-	ValidatorKey = "validator-key"
+	ValidatorKey = "evm-private-key"
 
 	// ValidatorBLSKey is the bls secret key of the validator node
-	ValidatorBLSKey = "validator-bls-key"
+	ValidatorBLSKey = "validator-bls-private-key"
 
 	// NetworkKey is the libp2p private key secret used for networking
-	NetworkKey = "network-key"
+	NetworkKey = "network-private-key"
 
 	// ValidatorBLSSignature is the BLS signature of the validator node
 	ValidatorBLSSignature = "validator-bls-signature"


### PR DESCRIPTION
# Description

- rename constant names for the secrets to be more precise;
- update the text of the public and private key outputs;
- separate both outputs for the registration and stake in the register-validator command, and only show the stake result, if it exists;
- remove the --chain-id flag from the register-validator command because it is redundant;
- remove the --chain-id from the docs where redundant;
- add the transaction hash to the error of the failed stake tx;

# Changes include

- [x] Minor, but important optimizations

# Checklist

- [x] I have added at least 1 reviewer
- [x] I have added the relevant labels
- [x] I have updated the official documentation
- [x] I have added sufficient documentation in code

## Testing

- [x] I have tested this code with the official test suite
- [x] I have tested this code manually

### Manual tests

I have executed the commands to test if all the changes are working.