### PR TITLE
195 optimize voting

### DIFF
--- a/price-oracle/mocks_test.go
+++ b/price-oracle/mocks_test.go
@@ -16,7 +16,6 @@ import (
 
 type MockPriceOracle struct {
 	PriceOracle
-	MockAlreadyVotedMapping map[uint64]bool
 }
 
 var _ contract.Provider = (*stateProviderMock)(nil)

--- a/price-oracle/price_oracle_test.go
+++ b/price-oracle/price_oracle_test.go
@@ -318,84 +318,68 @@ func TestShouldExecuteVote(t *testing.T) {
 	}
 
 	tests := []struct {
-		name                string
-		header              *types.Header
-		alreadyVoted        bool
-		priceUpdatedAlready bool
-		shouldMockState     bool
-		stateShouldVote     bool
-		stateShouldVoteErr  error
-		expectedResult      bool
-		expectedError       error
+		name               string
+		header             *types.Header
+		hasExecutedForDay  bool
+		shouldMockState    bool
+		stateShouldVote    bool
+		stateShouldVoteErr error
+		expectedResult     bool
+		expectedError      error
 	}{
 		{
-			name:                "Not in voting time",
-			header:              &types.Header{Timestamp: uint64(time.Date(2024, 10, 21, 0, 30, 0, 0, time.UTC).Unix())},
-			alreadyVoted:        false,
-			priceUpdatedAlready: false,
-			shouldMockState:     false,
-			stateShouldVote:     false,
-			expectedResult:      false,
-			expectedError:       nil,
+			name:              "Not in voting time",
+			header:            &types.Header{Timestamp: uint64(time.Date(2024, 10, 21, 0, 30, 0, 0, time.UTC).Unix())},
+			hasExecutedForDay: false,
+			shouldMockState:   false,
+			stateShouldVote:   false,
+			expectedResult:    false,
+			expectedError:     nil,
 		},
 		{
-			name:                "Already voted",
-			header:              &types.Header{Timestamp: uint64(time.Date(2024, 10, 21, 1, 0, 0, 0, time.UTC).Unix())},
-			alreadyVoted:        true,
-			priceUpdatedAlready: false,
-			shouldMockState:     false,
-			stateShouldVote:     false,
-			expectedResult:      false,
-			expectedError:       nil,
+			name:              "Should not vote because it has executed the required action for the day",
+			header:            &types.Header{Timestamp: uint64(time.Date(2024, 10, 21, 1, 0, 0, 0, time.UTC).Unix())},
+			hasExecutedForDay: true,
+			shouldMockState:   false,
+			stateShouldVote:   false,
+			expectedResult:    false,
+			expectedError:     nil,
 		},
 		{
-			name:                "Price updated already",
-			header:              &types.Header{Timestamp: uint64(time.Date(2024, 10, 21, 1, 0, 0, 0, time.UTC).Unix())},
-			alreadyVoted:        true,
-			priceUpdatedAlready: true,
-			shouldMockState:     false,
-			stateShouldVote:     false,
-			expectedResult:      false,
-			expectedError:       nil,
+			name:              "Should not vote based on state",
+			header:            &types.Header{Timestamp: uint64(time.Date(2024, 10, 21, 1, 0, 0, 0, time.UTC).Unix())},
+			hasExecutedForDay: false,
+			shouldMockState:   true,
+			stateShouldVote:   false,
+			expectedResult:    false,
+			expectedError:     nil,
 		},
 		{
-			name:                "Should not vote based on state",
-			header:              &types.Header{Timestamp: uint64(time.Date(2024, 10, 21, 1, 0, 0, 0, time.UTC).Unix())},
-			alreadyVoted:        false,
-			priceUpdatedAlready: false,
-			shouldMockState:     true,
-			stateShouldVote:     false,
-			expectedResult:      false,
-			expectedError:       nil,
+			name:               "Error in shouldVote",
+			header:             &types.Header{Timestamp: uint64(time.Date(2024, 10, 21, 1, 0, 0, 0, time.UTC).Unix())},
+			hasExecutedForDay:  false,
+			shouldMockState:    true,
+			stateShouldVote:    false,
+			stateShouldVoteErr: errors.New("should vote error"),
+			expectedResult:     false,
+			expectedError:      errors.New("should vote error"),
 		},
 		{
-			name:                "Error in shouldVote",
-			header:              &types.Header{Timestamp: uint64(time.Date(2024, 10, 21, 1, 0, 0, 0, time.UTC).Unix())},
-			alreadyVoted:        false,
-			priceUpdatedAlready: false,
-			shouldMockState:     true,
-			stateShouldVote:     false,
-			stateShouldVoteErr:  errors.New("should vote error"),
-			expectedResult:      false,
-			expectedError:       errors.New("should vote error"),
-		},
-		{
-			name:                "Should vote",
-			header:              &types.Header{Timestamp: uint64(time.Date(2024, 10, 21, 1, 0, 0, 0, time.UTC).Unix())},
-			alreadyVoted:        false,
-			priceUpdatedAlready: false,
-			shouldMockState:     true,
-			stateShouldVote:     true,
-			expectedResult:      true,
-			expectedError:       nil,
+			name:              "Should vote",
+			header:            &types.Header{Timestamp: uint64(time.Date(2024, 10, 21, 1, 0, 0, 0, time.UTC).Unix())},
+			hasExecutedForDay: false,
+			shouldMockState:   true,
+			stateShouldVote:   true,
+			expectedResult:    true,
+			expectedError:     nil,
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			// Set the alreadyVotedMapping state
+			// Set the hasExecutedForDay state
 			dayNumber := calcDayNumber(tt.header.Timestamp)
-			alreadyVotedMapping[dayNumber] = tt.alreadyVoted
+			hasExecutedForDay[dayNumber] = tt.hasExecutedForDay
 
 			if tt.shouldMockState {
 				// Mock the GetPriceOracleState and shouldVote methods
@@ -632,9 +616,9 @@ func TestExecuteVote(t *testing.T) {
 	// Assert that the appropriate log was found
 	require.True(t, foundVoteLog)
 
-	// Check if the alreadyVotedMapping was updated
+	// Check if the hasExecutedForDay was updated
 	dayNumber := calcDayNumber(header.Timestamp)
-	require.True(t, alreadyVotedMapping[dayNumber])
+	require.True(t, hasExecutedForDay[dayNumber])
 
 	// Assert that the mocks were called as expected
 	mockPriceFeed.AssertExpectations(t)
@@ -662,10 +646,9 @@ func TestExecuteVote_PriceFeedError(t *testing.T) {
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "price feed error")
 
-	// Check if the alreadyVotedMapping and priceUpdatedAlreadyMapping were not updated
+	// Check if the hasExecutedForDay not updated
 	dayNumber := calcDayNumber(header.Timestamp)
-	require.False(t, alreadyVotedMapping[dayNumber])
-	require.False(t, priceUpdatedAlreadyMapping[dayNumber])
+	require.False(t, hasExecutedForDay[dayNumber])
 
 	// Assert that the mocks were called as expected
 	mockPriceFeed.AssertExpectations(t)
@@ -697,10 +680,9 @@ func TestExecuteVote_VoteError(t *testing.T) {
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "vote: failed vote error")
 
-	// Check if the alreadyVotedMapping and priceUpdatedAlreadyMapping were not updated
+	// Check if the hasExecutedForDay not updated
 	dayNumber := calcDayNumber(header.Timestamp)
-	require.False(t, alreadyVotedMapping[dayNumber])
-	require.False(t, priceUpdatedAlreadyMapping[dayNumber])
+	require.False(t, hasExecutedForDay[dayNumber])
 
 	// Assert that the mocks were called as expected
 	mockPriceFeed.AssertExpectations(t)


### PR DESCRIPTION
# Description

- create a new condition to check when the price is already updated in the oracle;
- rename the alreadyVotedMapping to hasExecutedForDay in order to generalize and reuse it;
- adapt the variables in the tests and delete redundant mock variable;

# Changes include

- [x] New feature (non-breaking change that adds functionality)

# Breaking changes

Please complete this section if any breaking changes have been made, otherwise delete it

# Checklist

- [x] I have added at least 1 reviewer
- [x] I have added the relevant labels
- [x] I have updated the official documentation
- [x] I have added sufficient documentation in code

## Testing

- [x] I have tested this code with the official test suite
- [x] I have tested this code manually

### Manual tests

Since there was no point in modifying the contracts and creating the real case scenario, I tested with the false reason that the Price Oracle contract gave me and the flag for an already updated price works fine.