### PR TITLE
chore: fix linting

### DIFF
--- a/.github/paused-workflows/deploy.nightly.devnet.yml
+++ b/.github/paused-workflows/deploy.nightly.devnet.yml
@@ -218,7 +218,7 @@ jobs:
         id: url
         run: |
           terraform output -raw aws_lb_ext_domain | grep -o -E '^ext[^:]*' > rpc_url.txt
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
           name: rpc_url
           path: rpc_url.txt

--- a/.github/paused-workflows/e2e-polybft.yml
+++ b/.github/paused-workflows/e2e-polybft.yml
@@ -43,7 +43,7 @@ jobs:
 
       - name: Archive test logs
         if: always()
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: e2e-logs
           path: e2e-logs-*/

--- a/.github/paused-workflows/e2e.yaml
+++ b/.github/paused-workflows/e2e.yaml
@@ -42,7 +42,7 @@ jobs:
 
       - name: Archive test logs
         if: always()
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: e2e-logs
           path: e2e-logs-*/

--- a/.github/paused-workflows/property-polybft.yml
+++ b/.github/paused-workflows/property-polybft.yml
@@ -40,7 +40,7 @@ jobs:
 
       - name: Archive test logs
         if: always()
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: e2e-logs
           path: e2e-logs-*/

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -38,7 +38,7 @@ jobs:
         run: echo "build_output=false" >> $GITHUB_OUTPUT
 
       - name: 'Upload Artifact'
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: hydra
           path: hydra.tar.gz

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,12 +17,12 @@ jobs:
       build_output_failure: ${{ steps.hydra_build_failure.outputs.build_output }}
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         
       - name: Setup Go environment
-        uses: actions/setup-go@v3
+        uses: actions/setup-go@v5
         with:
-          go-version: 1.20.x
+          go-version: 1.23
 
       - name: Build HydraGon
         run: go build -tags netgo -o hydra -a -installsuffix cgo -ldflags="-s -w -linkmode external -extldflags \"-static\" -X \"github.com/Hydra-Chain/hydragon-node/versioning.Version=${GITHUB_REF_NAME}\" -X \"github.com/Hydra-Chain/hydragon-node/versioning.Commit=${GITHUB_SHA}\"" main.go && tar -czvf hydra.tar.gz hydra
@@ -50,12 +50,12 @@ jobs:
     continue-on-error: true
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Setup Go environment
-        uses: actions/setup-go@v3
+        uses: actions/setup-go@v5
         with:
-          go-version: 1.20.x
+          go-version: 1.23
 
       - name: 'Reproduce builds'
         continue-on-error: true

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -21,15 +21,15 @@ jobs:
   golangci_lint:
     runs-on: ubuntu-latest
     steps:
-      - name: Install Go
-        uses: actions/setup-go@v3
-        with:
-          go-version: 1.20.x
-
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
+
+      - name: Install Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: 1.23
 
       - name: Lint
-        uses: golangci/golangci-lint-action@v3
+        uses: golangci/golangci-lint-action@v6
         with:
           args: --timeout 10m --verbose

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,16 +18,16 @@ jobs:
     outputs:
       test_output_failure: ${{ steps.run_tests_failure.outputs.test_output }}
     steps:
-      - name: Setup Go
-        uses: actions/setup-go@v3
-        with:
-          go-version: 1.20.x
-
       - name: Checkout Code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           submodules: recursive
           fetch-depth: 0  # Shallow clones should be disabled for a better relevancy of analysis
+
+      - name: Setup Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: 1.23
 
       - name: Install Dependencies
         run: ./setup-ci.sh

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -8,7 +8,7 @@ linters:
   disable-all: true
   enable:
     - whitespace # Tool for detection of leading and trailing whitespace
-    - wsl # Forces you to use empty lines
+#    - wsl # Forces you to use empty lines
     - wastedassign # Finds wasted assignment statements
     - unconvert # Unnecessary type conversions
     - tparallel # Detects inappropriate usage of t.Parallel() method in your Go test codes
@@ -21,7 +21,6 @@ linters:
     - misspell # Misspelled English words in comments
     - makezero # Finds slice declarations with non-zero initial length
     - lll # Long lines
-    - importas # Enforces consistent import aliases
     - gosec # Security problems
     - gofmt # Whether the code was gofmt-ed
     - goimports # Unused imports
@@ -44,13 +43,20 @@ linters-settings:
   gocritic:
     enabled-checks:
       - ruleguard
+    disabled-checks:
+      - unslice # It should be enabled in the future.
     settings:
       ruleguard:
         rules: "./gorules/rules.go"
+  gosec:
+    excludes:
+      - G115
+  lll:
+    line-length: 150
 
 issues:
-  new-from-rev: origin/develop # report only new issues with reference to develop branch
-  whole-files: true
+  max-issues-per-linter: 0
+  max-same-issues: 0
   exclude-dirs:
     - tests
   exclude-rules:
@@ -66,7 +72,6 @@ issues:
         - unparam
         - lll
         - predeclared
-        - wsl
         - wastedassign
         - nolintlint
     - path: gen_sc_data\.go
@@ -79,3 +84,10 @@ issues:
     - EXC0013 # Package comment should be of the form "(.+)...
     - EXC0014 # Comment on exported (.+) should be of the form "(.+)..."
     - EXC0015 # Should have a package comment
+
+output:
+  sort-results: true
+  show-stats: true
+  sort-order:
+    - linter
+    - file

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -8,7 +8,7 @@ linters:
   disable-all: true
   enable:
     - whitespace # Tool for detection of leading and trailing whitespace
-#    - wsl # Forces you to use empty lines
+    - wsl # Forces you to use empty lines
     - wastedassign # Finds wasted assignment statements
     - unconvert # Unnecessary type conversions
     - tparallel # Detects inappropriate usage of t.Parallel() method in your Go test codes

--- a/archive/backup_test.go
+++ b/archive/backup_test.go
@@ -162,6 +162,7 @@ func Test_determineTo(t *testing.T) {
 
 			resTo, resToHash, err := determineTo(context.Background(), tt.systemClientMock, tt.targetTo)
 			assert.Equal(t, tt.err, err)
+
 			if tt.err == nil {
 				assert.Equal(t, tt.resTo, resTo)
 				assert.Equal(t, tt.resToHash, resToHash)
@@ -255,6 +256,7 @@ func Test_processExportStream(t *testing.T) {
 			from, to, err := processExportStream(tt.mockSystemExportClient, hclog.NewNullLogger(), &buffer, 0, 0)
 
 			assert.Equal(t, tt.err, err)
+
 			if err != nil {
 				return
 			}
@@ -264,12 +266,15 @@ func Test_processExportStream(t *testing.T) {
 
 			// create expected data
 			expectedData := make([]byte, 0)
+
 			for _, rv := range tt.mockSystemExportClient.recvs {
 				if rv.err != nil {
 					break
 				}
+
 				expectedData = append(expectedData, rv.event.Data...)
 			}
+
 			assert.Equal(t, expectedData, buffer.Bytes())
 		})
 	}

--- a/blockchain/blockchain.go
+++ b/blockchain/blockchain.go
@@ -1074,13 +1074,13 @@ func (b *Blockchain) verifyGasLimit(header *types.Header, parentHeader *types.He
 	}
 
 	// Find the absolute delta between the limits
-	diff := int64(parentHeader.GasLimit) - int64(header.GasLimit) //nolint:gosec
+	diff := int64(parentHeader.GasLimit) - int64(header.GasLimit)
 	if diff < 0 {
 		diff *= -1
 	}
 
 	limit := parentHeader.GasLimit / blockGasTargetDivisor
-	if uint64(diff) > limit { //nolint:gosec
+	if uint64(diff) > limit {
 		return fmt.Errorf(
 			"invalid gas limit, limit = %d, want %d +- %d",
 			header.GasLimit,

--- a/blockchain/blockchain_test.go
+++ b/blockchain/blockchain_test.go
@@ -450,6 +450,7 @@ func TestInsertHeaders(t *testing.T) {
 				if len(a) != len(b) {
 					t.Fatal("bad size")
 				}
+
 				for indx := range a {
 					if chain.headers[a[indx].hash].Hash != b[indx].Hash {
 						t.Fatal("bad")

--- a/blockchain/storage/leveldb/leveldb_test.go
+++ b/blockchain/storage/leveldb/leveldb_test.go
@@ -191,6 +191,7 @@ func dirSize(t *testing.T, path string) int64 {
 		if err != nil {
 			t.Fail()
 		}
+
 		if !info.IsDir() {
 			size += info.Size()
 		}

--- a/bls/arithmetic.go
+++ b/bls/arithmetic.go
@@ -31,8 +31,6 @@ func hashToPoint(msg, domain []byte) (*bn256.G1, error) {
 		return nil, err
 	}
 
-	//a = a.Mod(a, modulus)
-	//b = b.Mod(b, modulus)
 	a, b := res[0], res[1]
 
 	g1, err := mapToG1Point(a)
@@ -82,11 +80,13 @@ func hashToFpXMDSHA256(msg []byte, domain []byte, count int) ([]*big.Int, error)
 
 		// fast path
 		c := num.Cmp(modulus)
-		if c == 0 {
+
+		switch {
+		case c == 0:
 			// nothing
-		} else if c != 1 && num.Cmp(zero) != -1 {
+		case c != 1 && num.Cmp(zero) != -1:
 			// 0 < v < q
-		} else {
+		default:
 			num = num.Mod(num, modulus)
 		}
 
@@ -153,20 +153,20 @@ func expandMsgSHA256XMD(msg []byte, domain []byte, outLen int) ([]byte, error) {
 	return out[:outLen], nil
 }
 
-func mulmod(x, y, N *big.Int) *big.Int {
+func mulmod(x, y, n *big.Int) *big.Int {
 	xx := new(big.Int).Mul(x, y)
 
-	return xx.Mod(xx, N)
+	return xx.Mod(xx, n)
 }
 
-func addmod(x, y, N *big.Int) *big.Int {
+func addmod(x, y, n *big.Int) *big.Int {
 	xx := new(big.Int).Add(x, y)
 
-	return xx.Mod(xx, N)
+	return xx.Mod(xx, n)
 }
 
-func inversemod(x, N *big.Int) *big.Int {
-	return new(big.Int).ModInverse(x, N)
+func inversemod(x, n *big.Int) *big.Int {
+	return new(big.Int).ModInverse(x, n)
 }
 
 /**

--- a/command/bridge/common/params.go
+++ b/command/bridge/common/params.go
@@ -285,7 +285,7 @@ func (r *BridgeTxResult) GetOutput() string {
 	}
 
 	if r.ChildTokenAddr != nil {
-		vals = append(vals, fmt.Sprintf("Child Token Address|%s", (*r.ChildTokenAddr).String()))
+		vals = append(vals, fmt.Sprintf("Child Token Address|%s", r.ChildTokenAddr.String()))
 	}
 
 	_, _ = buffer.WriteString(fmt.Sprintf("\n[%s]\n", r.Title))

--- a/command/bridge/withdraw/erc1155/withdraw_erc1155.go
+++ b/command/bridge/withdraw/erc1155/withdraw_erc1155.go
@@ -173,12 +173,12 @@ func runCommand(cmd *cobra.Command, _ []string) {
 }
 
 // createWithdrawTxn encodes parameters for withdraw function on child chain predicate contract
-func createWithdrawTxn(receivers []ethgo.Address, amounts, TokenIDs []*big.Int) (*ethgo.Transaction, error) {
+func createWithdrawTxn(receivers []ethgo.Address, amounts, tokenIDs []*big.Int) (*ethgo.Transaction, error) {
 	withdrawFn := &contractsapi.WithdrawBatchChildERC1155PredicateFn{
 		ChildToken: types.StringToAddress(wp.TokenAddr),
 		Receivers:  receivers,
 		Amounts:    amounts,
-		TokenIDs:   TokenIDs,
+		TokenIDs:   tokenIDs,
 	}
 
 	input, err := withdrawFn.EncodeAbi()

--- a/command/genesis/params.go
+++ b/command/genesis/params.go
@@ -321,7 +321,7 @@ func (p *genesisParams) initValidatorSet() error {
 }
 
 func (p *genesisParams) isValidatorNumberValid() bool {
-	return p.ibftValidators == nil || uint64(p.ibftValidators.Len()) <= p.maxNumValidators //nolint:gosec
+	return p.ibftValidators == nil || uint64(p.ibftValidators.Len()) <= p.maxNumValidators
 }
 
 func (p *genesisParams) initIBFTExtraData() {
@@ -410,7 +410,7 @@ func (p *genesisParams) initGenesisConfig() error {
 			GasUsed:    command.DefaultGenesisGasUsed,
 		},
 		Params: &chain.Params{
-			ChainID: int64(p.chainID), //nolint:gosec
+			ChainID: int64(p.chainID),
 			Forks:   enabledForks,
 			Engine:  p.consensusEngineConfig,
 		},

--- a/command/genesis/params_test.go
+++ b/command/genesis/params_test.go
@@ -159,6 +159,7 @@ func Test_validatePremineInfo(t *testing.T) {
 			t.Parallel()
 
 			p := &genesisParams{premine: c.premineRaw}
+
 			err := p.parsePremineInfo()
 			if c.expectedParseErrMsg != "" {
 				require.ErrorContains(t, err, c.expectedParseErrMsg)

--- a/command/genesis/polybft_params.go
+++ b/command/genesis/polybft_params.go
@@ -148,7 +148,7 @@ func (p *genesisParams) generatePolyBftChainConfig(o command.OutputFormatter) er
 	chainConfig := &chain.Chain{
 		Name: p.name,
 		Params: &chain.Params{
-			ChainID: int64(p.chainID), //nolint:gosec
+			ChainID: int64(p.chainID),
 			Forks:   enabledForks,
 			Engine: map[string]interface{}{
 				string(server.PolyBFTConsensus): polyBftConfig,

--- a/command/peers/list/result.go
+++ b/command/peers/list/result.go
@@ -37,6 +37,7 @@ func (r *PeersListResult) GetOutput() string {
 		for i, p := range r.Peers {
 			rows[i] = fmt.Sprintf("[%d]|%s", i, p)
 		}
+
 		buffer.WriteString(helper.FormatKV(rows))
 	}
 

--- a/command/rootchain/server/server.go
+++ b/command/rootchain/server/server.go
@@ -189,6 +189,7 @@ func runRootchain(ctx context.Context, outputter command.OutputFormatter, closeC
 		// in current folder
 		pwdDir, err := os.Getwd()
 		if err != nil {
+			//nolint:gocritic // It should be fixed in the future.
 			log.Fatal(err)
 		} else {
 			mountDir = filepath.Join(pwdDir, params.dataDir)

--- a/consensus/ibft/consensus_backend.go
+++ b/consensus/ibft/consensus_backend.go
@@ -79,7 +79,7 @@ func (i *backendIBFT) InsertProposal(
 	// This is a safety net to help us narrow down and also recover before
 	// writing the block
 	if err := i.ValidateExtraDataFormat(newBlock.Header); err != nil {
-		//Format committed seals to make them more readable
+		// Format committed seals to make them more readable
 		committedSealsStr := make([]string, len(committedSealsMap))
 		for i, seal := range committedSeals {
 			committedSealsStr[i] = fmt.Sprintf("{signer=%v signature=%v}",

--- a/consensus/ibft/fork/helper_test.go
+++ b/consensus/ibft/fork/helper_test.go
@@ -149,6 +149,7 @@ func Test_readDataStore(t *testing.T) {
 
 		dirPath := createTestTempDirectory(t)
 		filePath := path.Join(dirPath, "test.dat")
+
 		var data interface{}
 
 		assert.Equal(

--- a/consensus/polybft/consensus_metrics.go
+++ b/consensus/polybft/consensus_metrics.go
@@ -16,8 +16,8 @@ const (
 // (such as block interval, number of transactions and block rounds metrics)
 func updateBlockMetrics(currentBlock *types.Block, parentHeader *types.Header) error {
 	if currentBlock.Number() > 1 {
-		parentTime := time.Unix(int64(parentHeader.Timestamp), 0)        //nolint:gosec
-		headerTime := time.Unix(int64(currentBlock.Header.Timestamp), 0) //nolint:gosec
+		parentTime := time.Unix(int64(parentHeader.Timestamp), 0)
+		headerTime := time.Unix(int64(currentBlock.Header.Timestamp), 0)
 		// update the block interval metric
 		metrics.SetGauge(
 			[]string{consensusMetricsPrefix, "block_interval"},

--- a/consensus/polybft/consensus_runtime.go
+++ b/consensus/polybft/consensus_runtime.go
@@ -239,7 +239,7 @@ func (c *consensusRuntime) initStakeManager(logger hcf.Logger, dbTx *bolt.Tx) er
 		wallet.NewEcdsaSigner(c.config.Key),
 		contracts.HydraStakingContract,
 		contracts.HydraChainContract,
-		int(c.config.PolyBFTConfig.MaxValidatorSetSize), //nolint:gosec
+		int(c.config.PolyBFTConfig.MaxValidatorSetSize),
 		c.config.polybftBackend,
 		dbTx,
 		c.config.blockchain,
@@ -690,7 +690,7 @@ func (c *consensusRuntime) calculateStateTxsInput(
 			EndBlock:   new(big.Int).SetUint64(currentBlock.Number + 1),
 			EpochRoot:  types.Hash{},
 		},
-		EpochSize: big.NewInt(int64(c.config.PolyBFTConfig.EpochSize)), //nolint:gosec
+		EpochSize: big.NewInt(int64(c.config.PolyBFTConfig.EpochSize)),
 		Uptime:    uptime,
 	}
 

--- a/consensus/polybft/consensus_runtime_test.go
+++ b/consensus/polybft/consensus_runtime_test.go
@@ -1285,6 +1285,7 @@ func createTestBitmaps(
 
 			if !bitmap.IsSet(index) {
 				bitmap.Set(index)
+
 				j++
 			}
 		}

--- a/consensus/polybft/extra_test.go
+++ b/consensus/polybft/extra_test.go
@@ -377,6 +377,7 @@ func TestSignature_Verify(t *testing.T) {
 		validatorSet := vals.ToValidatorSet()
 
 		var signatures bls.Signatures
+
 		bitmap := bitmap.Bitmap{}
 		signers := make(map[types.Address]struct{}, len(validatorsMetadata))
 
@@ -503,6 +504,7 @@ func TestExtra_InitGenesisValidatorsDelta(t *testing.T) {
 		}
 
 		var i int
+
 		for _, val := range vals.Validators {
 			delta.Added[i] = &validator.ValidatorMetadata{
 				Address:     types.Address(val.Account.Ecdsa.Address()),
@@ -731,6 +733,7 @@ func TestCheckpointData_Validate(t *testing.T) {
 		c := c
 		t.Run(c.name, func(t *testing.T) {
 			t.Parallel()
+
 			checkpoint := &CheckpointData{
 				EpochNumber:           c.epochNumber,
 				CurrentValidatorsHash: c.currentValidatorsHash,

--- a/consensus/polybft/fsm.go
+++ b/consensus/polybft/fsm.go
@@ -792,7 +792,7 @@ func (f *fsm) Insert(
 
 		signatures = append(signatures, s)
 
-		bitmap.Set(uint64(index)) //nolint:gosec
+		bitmap.Set(uint64(index))
 	}
 
 	aggregatedSignature, err := signatures.Aggregate().Marshal()
@@ -1006,10 +1006,10 @@ func validateHeaderFields(parent *types.Header, header *types.Header, blockTimeD
 		return fmt.Errorf("invalid number")
 	}
 	// verify time is from the future
-	if header.Timestamp > (uint64(time.Now().UTC().Unix()) + blockTimeDrift) { //nolint:gosec
+	if header.Timestamp > (uint64(time.Now().UTC().Unix()) + blockTimeDrift) {
 		return fmt.Errorf(
 			"block from the future. block timestamp: %s, configured block time drift %d seconds",
-			time.Unix(int64(header.Timestamp), 0).Format(time.RFC3339), //nolint:gosec
+			time.Unix(int64(header.Timestamp), 0).Format(time.RFC3339),
 			blockTimeDrift,
 		)
 	}

--- a/consensus/polybft/fsm_test.go
+++ b/consensus/polybft/fsm_test.go
@@ -40,6 +40,7 @@ func TestFSM_ValidateHeader(t *testing.T) {
 		validateHeaderFields(parent, header, blockTimeDrift),
 		"extra-data shorter than",
 	)
+
 	header.ExtraData = extra
 
 	// parent hash
@@ -48,6 +49,7 @@ func TestFSM_ValidateHeader(t *testing.T) {
 		validateHeaderFields(parent, header, blockTimeDrift),
 		"incorrect header parent hash",
 	)
+
 	header.ParentHash = parent.Hash
 
 	// sequence number
@@ -61,6 +63,7 @@ func TestFSM_ValidateHeader(t *testing.T) {
 		validateHeaderFields(parent, header, blockTimeDrift),
 		"timestamp older than parent",
 	)
+
 	header.Timestamp = 10
 
 	// failed nonce
@@ -77,6 +80,7 @@ func TestFSM_ValidateHeader(t *testing.T) {
 		validateHeaderFields(parent, header, blockTimeDrift),
 		"invalid gas limit",
 	)
+
 	header.GasLimit = 10
 	header.GasUsed = 10
 
@@ -86,6 +90,7 @@ func TestFSM_ValidateHeader(t *testing.T) {
 		validateHeaderFields(parent, header, blockTimeDrift),
 		"mix digest is not correct",
 	)
+
 	header.MixHash = HydragonMixDigest
 
 	// difficulty
@@ -103,7 +108,9 @@ func TestFSM_ValidateHeader(t *testing.T) {
 		validateHeaderFields(parent, header, blockTimeDrift),
 		"invalid header hash",
 	)
+
 	header.Timestamp = uint64(time.Now().UTC().Unix() + 150)
+
 	require.ErrorContains(
 		t,
 		validateHeaderFields(parent, header, blockTimeDrift),

--- a/consensus/polybft/mocks_test.go
+++ b/consensus/polybft/mocks_test.go
@@ -372,13 +372,13 @@ func (tp *txPoolMock) Prepare() {
 func (tp *txPoolMock) Length() uint64 {
 	args := tp.Called()
 
-	return args[0].(uint64) // nolint
+	return args[0].(uint64) //nolint:forcetypeassert
 }
 
 func (tp *txPoolMock) Peek() *types.Transaction {
 	args := tp.Called()
 
-	return args[0].(*types.Transaction) // nolint
+	return args[0].(*types.Transaction) //nolint:forcetypeassert
 }
 
 func (tp *txPoolMock) Pop(tx *types.Transaction) {
@@ -422,13 +422,13 @@ func (tp *syncerMock) Close() error {
 func (tp *syncerMock) GetSyncProgression() *progress.Progression {
 	args := tp.Called()
 
-	return args[0].(*progress.Progression) // nolint
+	return args[0].(*progress.Progression) //nolint:forcetypeassert
 }
 
 func (tp *syncerMock) HasSyncPeer() bool {
 	args := tp.Called()
 
-	return args[0].(bool) // nolint
+	return args[0].(bool) //nolint:forcetypeassert
 }
 
 func (tp *syncerMock) Sync(func(*types.FullBlock) bool) error {

--- a/consensus/polybft/mocks_test.go
+++ b/consensus/polybft/mocks_test.go
@@ -261,6 +261,7 @@ func (s *systemStateMock) GetEpoch() (uint64, error) {
 		return epochNumber, nil
 	} else if len(args) == 2 {
 		epochNumber, _ := args.Get(0).(uint64)
+
 		err, ok := args.Get(1).(error)
 		if ok {
 			return epochNumber, err
@@ -291,6 +292,7 @@ func (s *systemStateMock) GetVotingPowerExponent() (*big.Int, error) {
 func (s *systemStateMock) GetValidatorBalance(addr types.Address) (balance *big.Int, err error) {
 	args := s.Called(addr)
 	balance, _ = args.Get(0).(*big.Int)
+
 	if args.Get(1) != nil {
 		err, _ = args.Get(1).(error)
 	}
@@ -370,13 +372,13 @@ func (tp *txPoolMock) Prepare() {
 func (tp *txPoolMock) Length() uint64 {
 	args := tp.Called()
 
-	return args[0].(uint64) //nolint
+	return args[0].(uint64) // nolint
 }
 
 func (tp *txPoolMock) Peek() *types.Transaction {
 	args := tp.Called()
 
-	return args[0].(*types.Transaction) //nolint
+	return args[0].(*types.Transaction) // nolint
 }
 
 func (tp *txPoolMock) Pop(tx *types.Transaction) {
@@ -420,13 +422,13 @@ func (tp *syncerMock) Close() error {
 func (tp *syncerMock) GetSyncProgression() *progress.Progression {
 	args := tp.Called()
 
-	return args[0].(*progress.Progression) //nolint
+	return args[0].(*progress.Progression) // nolint
 }
 
 func (tp *syncerMock) HasSyncPeer() bool {
 	args := tp.Called()
 
-	return args[0].(bool) //nolint
+	return args[0].(bool) // nolint
 }
 
 func (tp *syncerMock) Sync(func(*types.FullBlock) bool) error {

--- a/consensus/polybft/polybft.go
+++ b/consensus/polybft/polybft.go
@@ -474,7 +474,7 @@ func (p *Polybft) Initialize() error {
 		p.config.Logger.Named("syncer"),
 		p.config.Network,
 		p.config.Blockchain,
-		time.Duration(p.config.BlockTime)*3*time.Second, //nolint:gosec
+		time.Duration(p.config.BlockTime)*3*time.Second,
 	)
 
 	// set blockchain backend
@@ -489,7 +489,7 @@ func (p *Polybft) Initialize() error {
 	}
 
 	// set block time
-	p.blockTime = time.Duration(p.config.BlockTime) //nolint:gosec
+	p.blockTime = time.Duration(p.config.BlockTime)
 
 	// initialize polybft consensus data directory
 	p.dataDir = filepath.Join(p.config.Config.Path, "hydragon")

--- a/consensus/polybft/proposer_calculator.go
+++ b/consensus/polybft/proposer_calculator.go
@@ -473,19 +473,19 @@ func rescalePriorities(snapshot *ProposerSnapshot, totalVotingPower *big.Int) er
 
 // computeMaxMinPriorityDiff computes the difference between the max and min ProposerPriority of that set.
 func computeMaxMinPriorityDiff(validators []*PrioritizedValidator) *big.Int {
-	min, max := validators[0].ProposerPriority, validators[0].ProposerPriority
+	minimum, maximum := validators[0].ProposerPriority, validators[0].ProposerPriority
 
 	for _, v := range validators[1:] {
-		if v.ProposerPriority.Cmp(min) < 0 {
-			min = v.ProposerPriority
+		if v.ProposerPriority.Cmp(minimum) < 0 {
+			minimum = v.ProposerPriority
 		}
 
-		if v.ProposerPriority.Cmp(max) > 0 {
-			max = v.ProposerPriority
+		if v.ProposerPriority.Cmp(maximum) > 0 {
+			maximum = v.ProposerPriority
 		}
 	}
 
-	diff := new(big.Int).Sub(max, min)
+	diff := new(big.Int).Sub(maximum, minimum)
 
 	if diff.Cmp(big.NewInt(0)) < 0 {
 		return diff.Neg(diff)

--- a/consensus/polybft/stake_manager.go
+++ b/consensus/polybft/stake_manager.go
@@ -360,7 +360,7 @@ func (s *stakeManager) UpdateValidatorSet(
 		oldActiveMap[validator.Address] = validator
 		// remove existing validators from the validators list if they did not make it to the list
 		if _, exists := addressesSet[validator.Address]; !exists {
-			removedBitmap.Set(uint64(i)) //nolint:gosec
+			removedBitmap.Set(uint64(i))
 		}
 	}
 

--- a/consensus/polybft/stake_manager_fuzz_test.go
+++ b/consensus/polybft/stake_manager_fuzz_test.go
@@ -99,7 +99,9 @@ func FuzzTestStakeManagerPostBlock(f *testing.F) {
 		systemStateMockVar := new(systemStateMock)
 		vPowerExp := big.NewInt(5000)
 		systemStateMockVar.On("GetVotingPowerExponent").Return(vPowerExp, nil).Maybe()
+
 		bcMock := new(blockchainMock)
+
 		for i := 0; i < int(data.BlockID); i++ {
 			bcMock.On("CurrentHeader").Return(&types.Header{Number: 0})
 			bcMock.On("GetHeaderByNumber", mock.Anything).

--- a/consensus/polybft/stake_manager_test.go
+++ b/consensus/polybft/stake_manager_test.go
@@ -105,8 +105,9 @@ func TestStakeManager_PostBlock(t *testing.T) {
 
 		fullValidatorSet, err := state.StakeStore.getFullValidatorSet(nil)
 		require.NoError(t, err)
+
 		var firstValidatorMeta *validator.ValidatorMetadata
-		firstValidatorMeta = nil
+
 		for _, validator := range fullValidatorSet.Validators {
 			if validator.Address.String() == validators.GetValidator(initialSetAliases[firstValidator]).
 				Address().
@@ -114,6 +115,7 @@ func TestStakeManager_PostBlock(t *testing.T) {
 				firstValidatorMeta = validator
 			}
 		}
+
 		require.NotNil(t, firstValidatorMeta)
 		require.Equal(t, bigZero, firstValidatorMeta.VotingPower)
 		require.False(t, firstValidatorMeta.IsActive)
@@ -177,8 +179,10 @@ func TestStakeManager_PostBlock(t *testing.T) {
 
 		fullValidatorSet, err := state.StakeStore.getFullValidatorSet(nil)
 		require.NoError(t, err)
+
 		var firstValidator *validator.ValidatorMetadata
 		firstValidator = nil
+
 		for _, validator := range fullValidatorSet.Validators {
 			if validator.Address.String() == validators.GetValidator(initialSetAliases[secondValidator]).
 				Address().
@@ -186,6 +190,7 @@ func TestStakeManager_PostBlock(t *testing.T) {
 				firstValidator = validator
 			}
 		}
+
 		require.NotNil(t, firstValidator)
 		require.Equal(
 			t,
@@ -333,6 +338,7 @@ func TestStakeManager_PostBlock(t *testing.T) {
 
 		fullValidatorSet, err := state.StakeStore.getFullValidatorSet(nil)
 		require.NoError(t, err)
+
 		for _, val := range fullValidatorSet.Validators {
 			require.NotNil(t, val)
 			require.Equal(
@@ -435,6 +441,7 @@ func TestStakeManager_UpdateValidatorSet(t *testing.T) {
 		fullValidatorSet := validators.GetPublicIdentities().Copy()
 		validatorToUpdate := fullValidatorSet[2]
 		validatorToUpdate.VotingPower = big.NewInt(5)
+
 		require.NoError(t, state.StakeStore.insertFullValidatorSet(validatorSetState{
 			Validators: newValidatorStakeMap(fullValidatorSet),
 		}, nil))
@@ -458,6 +465,7 @@ func TestStakeManager_UpdateValidatorSet(t *testing.T) {
 		fullValidatorSet := validators.GetPublicIdentities().Copy()
 		validatorToUpdate := fullValidatorSet[3]
 		validatorToUpdate.VotingPower = bigZero
+
 		require.NoError(t, state.StakeStore.insertFullValidatorSet(validatorSetState{
 			Validators: newValidatorStakeMap(fullValidatorSet),
 		}, nil))
@@ -475,6 +483,7 @@ func TestStakeManager_UpdateValidatorSet(t *testing.T) {
 		fullValidatorSet := validators.GetPublicIdentities().Copy()
 		validatorsToUpdate := fullValidatorSet[4]
 		validatorsToUpdate.VotingPower = bigZero
+
 		require.NoError(t, state.StakeStore.insertFullValidatorSet(validatorSetState{
 			Validators: newValidatorStakeMap(fullValidatorSet),
 		}, nil))

--- a/consensus/polybft/state_store_epoch_test.go
+++ b/consensus/polybft/state_store_epoch_test.go
@@ -91,6 +91,7 @@ func TestState_cleanValidatorSnapshotsFromDb(t *testing.T) {
 		snapshotFromDB, err = state.EpochStore.getValidatorSnapshot(epoch)
 		assert.NoError(t, err)
 		assert.NotNil(t, snapshotFromDB)
+
 		epoch--
 	}
 }

--- a/consensus/polybft/validator/test_helpers.go
+++ b/consensus/polybft/validator/test_helpers.go
@@ -167,11 +167,13 @@ func (v *TestValidator) ParamsValidator() *GenesisValidator {
 		signer.DomainHydraChain,
 	)
 	if err != nil {
+		//nolint:gocritic // It should be fixed in the future.
 		panic(fmt.Sprintf("BUG: failed to sign validator params: %v", err))
 	}
 
 	signatureBytes, err := blsSignature.Marshal()
 	if err != nil {
+		//nolint:gocritic // It should be fixed in the future.
 		panic(fmt.Sprintf("BUG: failed to marshal validator params signature: %v", err))
 	}
 

--- a/consensus/polybft/validator/test_helpers.go
+++ b/consensus/polybft/validator/test_helpers.go
@@ -160,6 +160,7 @@ func (v *TestValidator) Key() *wallet.Key {
 
 func (v *TestValidator) ParamsValidator() *GenesisValidator {
 	blskey := v.Account.Bls.PublicKey().Marshal()
+
 	blsSignature, err := signer.MakeKOSKSignature(
 		v.Account.Bls,
 		types.Address(v.Account.Ecdsa.Address()),

--- a/consensus/polybft/validator/validator_metadata_test.go
+++ b/consensus/polybft/validator/validator_metadata_test.go
@@ -274,10 +274,12 @@ func TestAccountSet_ApplyDelta(t *testing.T) {
 				if step.added != nil {
 					addedValidators = vals.GetPublicIdentities(step.added...)
 				}
+
 				delta := &ValidatorSetDelta{
 					Added:   addedValidators,
 					Removed: bitmap.Bitmap{},
 				}
+
 				for _, i := range step.removed {
 					delta.Removed.Set(i)
 				}
@@ -287,6 +289,7 @@ func TestAccountSet_ApplyDelta(t *testing.T) {
 
 				// apply delta
 				var err error
+
 				snapshot, err = snapshot.ApplyDelta(delta)
 				if step.errMsg != "" {
 					require.ErrorContains(t, err, step.errMsg)
@@ -294,10 +297,12 @@ func TestAccountSet_ApplyDelta(t *testing.T) {
 
 					return
 				}
+
 				require.NoError(t, err)
 
 				// validate validator set
 				require.Equal(t, len(step.expected), snapshot.Len())
+
 				for validatorAlias, votingPower := range step.expected {
 					v := vals.GetValidator(validatorAlias).ValidatorMetadata()
 					require.True(t, snapshot.ContainsAddress(v.Address), "validator '%s' not found in snapshot", validatorAlias)

--- a/consensus/polybft/validator/validator_set_delta_test.go
+++ b/consensus/polybft/validator/validator_set_delta_test.go
@@ -84,6 +84,7 @@ func TestValidatorSetDelta_UnmarshalRLPWith_NegativeCases(t *testing.T) {
 		deltaMarshalled.Set(ar.NewBytes([]byte{0x33}))
 		deltaMarshalled.Set(ar.NewBytes([]byte{0x26}))
 		deltaMarshalled.Set(ar.NewBytes([]byte{0x74}))
+
 		delta := &ValidatorSetDelta{}
 		require.ErrorContains(t, delta.UnmarshalRLPWith(deltaMarshalled), "incorrect elements count to decode validator set delta, expected 3 but found 4")
 	})
@@ -96,6 +97,7 @@ func TestValidatorSetDelta_UnmarshalRLPWith_NegativeCases(t *testing.T) {
 		deltaMarshalled.Set(ar.NewBytes([]byte{0x59}))
 		deltaMarshalled.Set(ar.NewBytes([]byte{0x33}))
 		deltaMarshalled.Set(ar.NewBytes([]byte{0x27}))
+
 		delta := &ValidatorSetDelta{}
 		require.ErrorContains(t, delta.UnmarshalRLPWith(deltaMarshalled), "array expected for added validators")
 	})
@@ -110,6 +112,7 @@ func TestValidatorSetDelta_UnmarshalRLPWith_NegativeCases(t *testing.T) {
 		deltaMarshalled.Set(addedArray)
 		deltaMarshalled.Set(ar.NewNullArray())
 		deltaMarshalled.Set(ar.NewNull())
+
 		delta := &ValidatorSetDelta{}
 		require.ErrorContains(t, delta.UnmarshalRLPWith(deltaMarshalled), "value is not of type array")
 	})
@@ -122,9 +125,11 @@ func TestValidatorSetDelta_UnmarshalRLPWith_NegativeCases(t *testing.T) {
 		addedValidators := NewTestValidators(t, 3).GetPublicIdentities()
 		addedArray := ar.NewArray()
 		updatedArray := ar.NewArray()
+
 		for _, validator := range addedValidators {
 			addedArray.Set(validator.MarshalRLPWith(ar))
 		}
+
 		for _, validator := range addedValidators {
 			votingPower, err := rand.Int(rand.Reader, big.NewInt(100))
 			require.NoError(t, err)
@@ -132,9 +137,11 @@ func TestValidatorSetDelta_UnmarshalRLPWith_NegativeCases(t *testing.T) {
 			validator.VotingPower = new(big.Int).Set(votingPower)
 			updatedArray.Set(validator.MarshalRLPWith(ar))
 		}
+
 		deltaMarshalled.Set(addedArray)
 		deltaMarshalled.Set(updatedArray)
 		deltaMarshalled.Set(ar.NewNull())
+
 		delta := &ValidatorSetDelta{}
 		require.ErrorContains(t, delta.UnmarshalRLPWith(deltaMarshalled), "value is not of type bytes")
 	})
@@ -147,6 +154,7 @@ func TestValidatorSetDelta_UnmarshalRLPWith_NegativeCases(t *testing.T) {
 		deltaMarshalled.Set(ar.NewArray())
 		deltaMarshalled.Set(ar.NewBytes([]byte{0x33}))
 		deltaMarshalled.Set(ar.NewNull())
+
 		delta := &ValidatorSetDelta{}
 		require.ErrorContains(t, delta.UnmarshalRLPWith(deltaMarshalled), "array expected for updated validators")
 	})
@@ -161,6 +169,7 @@ func TestValidatorSetDelta_UnmarshalRLPWith_NegativeCases(t *testing.T) {
 		deltaMarshalled.Set(ar.NewArray())
 		deltaMarshalled.Set(updatedArray)
 		deltaMarshalled.Set(ar.NewNull())
+
 		delta := &ValidatorSetDelta{}
 		require.ErrorContains(t, delta.UnmarshalRLPWith(deltaMarshalled), "value is not of type array")
 	})
@@ -197,20 +206,25 @@ func TestExtra_CreateValidatorSetDelta_Cases(t *testing.T) {
 			for _, name := range c.oldSet {
 				vals.Create(t, name, 1)
 			}
+
 			for _, name := range c.newSet {
 				vals.Create(t, name, 1)
 			}
 
 			oldValidatorSet := vals.GetPublicIdentities(c.oldSet...)
+
 			// update voting power to random value
 			maxVotingPower := big.NewInt(100)
+
 			for _, name := range c.updated {
 				v := vals.GetValidator(name)
 				vp, err := rand.Int(rand.Reader, maxVotingPower)
 				require.NoError(t, err)
+
 				// make sure generated voting power is different than the original one
 				v.VotingPower += vp.Uint64() + 1
 			}
+
 			newValidatorSet := vals.GetPublicIdentities(c.newSet...)
 
 			delta, err := CreateValidatorSetDelta(oldValidatorSet, newValidatorSet)
@@ -218,6 +232,7 @@ func TestExtra_CreateValidatorSetDelta_Cases(t *testing.T) {
 
 			// added validators
 			require.Len(t, delta.Added, len(c.added))
+
 			for i, name := range c.added {
 				require.Equal(t, delta.Added[i].Address, vals.GetValidator(name).Address())
 			}
@@ -229,6 +244,7 @@ func TestExtra_CreateValidatorSetDelta_Cases(t *testing.T) {
 
 			// updated validators
 			require.Len(t, delta.Updated, len(c.updated))
+
 			for i, name := range c.updated {
 				require.Equal(t, delta.Updated[i].Address, vals.GetValidator(name).Address())
 			}

--- a/consensus/polybft/validators_snapshot_test.go
+++ b/consensus/polybft/validators_snapshot_test.go
@@ -149,6 +149,7 @@ func TestValidatorsSnapshotCache_Cleanup(t *testing.T) {
 
 	for i := uint64(0); i < validatorSnapshotLimit; i++ {
 		require.NoError(cache.storeSnapshot(&validatorSnapshot{i, i * 10, snapshot}, nil))
+
 		maxEpoch++
 	}
 

--- a/contracts/staking/query_test.go
+++ b/contracts/staking/query_test.go
@@ -113,6 +113,7 @@ func Test_decodeValidators(t *testing.T) {
 			} else {
 				assert.Error(t, err)
 			}
+
 			assert.Equal(t, tt.expected, res)
 		})
 	}
@@ -221,6 +222,7 @@ func TestQueryValidators(t *testing.T) {
 			} else {
 				assert.Error(t, err)
 			}
+
 			assert.Equal(t, tt.expected, res)
 		})
 	}

--- a/crypto/txsigner.go
+++ b/crypto/txsigner.go
@@ -48,15 +48,15 @@ func NewSigner(forks chain.ForksInTime, chainID uint64) TxSigner {
 }
 
 // encodeSignature generates a signature value based on the R, S and V value
-func encodeSignature(R, S, V *big.Int, isHomestead bool) ([]byte, error) {
-	if !ValidateSignatureValues(V, R, S, isHomestead) {
+func encodeSignature(r, s, v *big.Int, isHomestead bool) ([]byte, error) {
+	if !ValidateSignatureValues(v, r, s, isHomestead) {
 		return nil, fmt.Errorf("invalid txn signature")
 	}
 
 	sig := make([]byte, 65)
-	copy(sig[32-len(R.Bytes()):32], R.Bytes())
-	copy(sig[64-len(S.Bytes()):64], S.Bytes())
-	sig[64] = byte(V.Int64()) // here is safe to convert it since ValidateSignatureValues will validate the v value
+	copy(sig[32-len(r.Bytes()):32], r.Bytes())
+	copy(sig[64-len(s.Bytes()):64], s.Bytes())
+	sig[64] = byte(v.Int64()) // here is safe to convert it since ValidateSignatureValues will validate the v value
 
 	return sig, nil
 }
@@ -92,7 +92,7 @@ func calcTxHash(tx *types.Transaction, chainID uint64) types.Hash {
 	if tx.To == nil {
 		v.Set(a.NewNull())
 	} else {
-		v.Set(a.NewCopyBytes((*tx.To).Bytes()))
+		v.Set(a.NewCopyBytes(tx.To.Bytes()))
 	}
 
 	v.Set(a.NewBigInt(tx.Value))

--- a/gasprice/feehistory.go
+++ b/gasprice/feehistory.go
@@ -88,7 +88,7 @@ func (g *GasHelper) FeeHistory(blockCount uint64, newestBlock uint64, rewardPerc
 
 	for i := oldestBlock; i <= newestBlock; i++ {
 		cacheKey := cacheKey{number: i, percentiles: string(percentileKey)}
-		//cache is hit, load from cache and continue to next block
+		// cache is hit, load from cache and continue to next block
 		if p, ok := g.historyCache.Get(cacheKey); ok {
 			processedFee, isOk := p.(*processedFees)
 			if !isOk {
@@ -111,12 +111,12 @@ func (g *GasHelper) FeeHistory(blockCount uint64, newestBlock uint64, rewardPerc
 		gasUsedRatio[i-oldestBlock] = float64(block.Header.GasUsed) / float64(block.Header.GasLimit)
 
 		if math.IsNaN(gasUsedRatio[i-oldestBlock]) {
-			//gasUsedRatio is NaN, set to 0
+			// gasUsedRatio is NaN, set to 0
 			gasUsedRatio[i-oldestBlock] = 0
 		}
 
 		if len(rewardPercentiles) == 0 {
-			//reward percentiles not requested, skip rest of this loop
+			// reward percentiles not requested, skip rest of this loop
 			continue
 		}
 
@@ -125,7 +125,7 @@ func (g *GasHelper) FeeHistory(blockCount uint64, newestBlock uint64, rewardPerc
 			for j := range reward[i-oldestBlock] {
 				reward[i-oldestBlock][j] = 0
 			}
-			//no transactions in block, set rewards to 0 and move to next block
+			// no transactions in block, set rewards to 0 and move to next block
 			continue
 		}
 

--- a/go.mod
+++ b/go.mod
@@ -1,11 +1,16 @@
 module github.com/0xPolygon/polygon-edge
 
-go 1.20
+go 1.21
 
 require (
+	cloud.google.com/go/secretmanager v1.13.0
+	github.com/Hydra-Chain/go-ibft v0.4.4-hydra
+	github.com/armon/go-metrics v0.4.1
+	github.com/aws/aws-sdk-go v1.52.2
 	github.com/btcsuite/btcd v0.22.1
-	github.com/containerd/cgroups v1.1.0 // indirect
-	github.com/elastic/gosigar v0.14.2 // indirect
+	github.com/coinbase/kryptology v1.8.0
+	github.com/docker/docker v24.0.7+incompatible
+	github.com/docker/go-connections v0.5.0
 	github.com/envoyproxy/protoc-gen-validate v1.0.4
 	github.com/golang/protobuf v1.5.4
 	github.com/google/uuid v1.6.0
@@ -19,59 +24,31 @@ require (
 	github.com/libp2p/go-libp2p v0.32.0
 	github.com/libp2p/go-libp2p-kbucket v0.6.3
 	github.com/libp2p/go-libp2p-pubsub v0.10.1
-	github.com/miekg/dns v1.1.56 // indirect
-	github.com/multiformats/go-base32 v0.1.0 // indirect
+	github.com/mitchellh/mapstructure v1.5.0
 	github.com/multiformats/go-multiaddr v0.12.3
-	github.com/multiformats/go-multihash v0.2.3 // indirect
 	github.com/prometheus/client_golang v1.18.0
+	github.com/quasilyte/go-ruleguard v0.4.0
+	github.com/quasilyte/go-ruleguard/dsl v0.3.22
 	github.com/ryanuber/columnize v2.1.2+incompatible
+	github.com/sethvargo/go-retry v0.2.4
 	github.com/spf13/cobra v1.8.0
 	github.com/stretchr/testify v1.9.0
 	github.com/syndtr/goleveldb v1.0.1-0.20220721030215-126854af5e6d
+	github.com/trailofbits/go-fuzz-utils v0.0.0-20210901195358-9657fcfd256c
+	github.com/umbracle/ethgo v0.1.4-0.20231006072852-6b068360fc97
 	github.com/umbracle/fastrlp v0.1.1-0.20230504065717-58a1b8a9929d
 	github.com/umbracle/go-eth-bn256 v0.0.0-20230125114011-47cb310d9b0b
-	golang.org/x/crypto v0.22.0
-	google.golang.org/grpc v1.63.2
-	google.golang.org/protobuf v1.34.0
-	gopkg.in/natefinch/npipe.v2 v2.0.0-20160621034901-c1b8fa8bdcce
-)
-
-require (
-	cloud.google.com/go/secretmanager v1.13.0
-	github.com/armon/go-metrics v0.4.1
-	github.com/aws/aws-sdk-go v1.52.2
-	github.com/benbjohnson/clock v1.3.5 // indirect
-	github.com/coinbase/kryptology v1.8.0
-	github.com/fatih/color v1.15.0 // indirect
-	github.com/godbus/dbus/v5 v5.1.0 // indirect
-	github.com/ipfs/go-cid v0.4.1 // indirect
-	github.com/klauspost/compress v1.17.2 // indirect
-	github.com/mattn/go-colorable v0.1.13 // indirect
-	github.com/mitchellh/mapstructure v1.5.0
-	github.com/umbracle/ethgo v0.1.4-0.20231006072852-6b068360fc97
-	github.com/valyala/fastjson v1.6.3 // indirect
-	go.uber.org/zap v1.26.0 // indirect
-	golang.org/x/sys v0.19.0 // indirect
-	golang.org/x/tools v0.17.0
-	gopkg.in/yaml.v3 v3.0.1
-	lukechampine.com/blake3 v1.2.1 // indirect
-)
-
-require (
-	github.com/docker/docker v24.0.7+incompatible
-	github.com/docker/go-connections v0.5.0
 	go.etcd.io/bbolt v1.3.8
-)
-
-require (
-	github.com/Hydra-Chain/go-ibft v0.4.4-hydra
-	github.com/quasilyte/go-ruleguard v0.4.0
-	github.com/quasilyte/go-ruleguard/dsl v0.3.22
-	github.com/sethvargo/go-retry v0.2.4
+	golang.org/x/crypto v0.22.0
 	golang.org/x/sync v0.7.0
 	golang.org/x/term v0.19.0
+	golang.org/x/tools v0.17.0
 	google.golang.org/genproto v0.0.0-20240401170217-c3f982113cda
+	google.golang.org/grpc v1.63.2
+	google.golang.org/protobuf v1.34.0
 	gopkg.in/DataDog/dd-trace-go.v1 v1.63.1
+	gopkg.in/natefinch/npipe.v2 v2.0.0-20160621034901-c1b8fa8bdcce
+	gopkg.in/yaml.v3 v3.0.1
 	pgregory.net/rapid v1.1.0
 )
 
@@ -79,52 +56,21 @@ require (
 	cloud.google.com/go/auth v0.3.0 // indirect
 	cloud.google.com/go/auth/oauth2adapt v0.2.2 // indirect
 	cloud.google.com/go/compute/metadata v0.3.0 // indirect
-	github.com/DataDog/appsec-internal-go v1.5.0 // indirect
-	github.com/DataDog/datadog-agent/pkg/remoteconfig/state v0.48.1 // indirect
-	github.com/DataDog/go-libddwaf/v2 v2.4.2 // indirect
-	github.com/DataDog/go-tuf v1.0.2-0.5.2 // indirect
-	github.com/ebitengine/purego v0.6.0-alpha.5 // indirect
-	github.com/felixge/httpsnoop v1.0.4 // indirect
-	github.com/go-jose/go-jose/v3 v3.0.1 // indirect
-	github.com/go-logr/logr v1.4.1 // indirect
-	github.com/go-logr/stdr v1.2.2 // indirect
-	github.com/google/s2a-go v0.1.7 // indirect
-	github.com/hashicorp/golang-lru/v2 v2.0.5 // indirect
-	github.com/ipfs/boxo v0.8.1 // indirect
-	github.com/libp2p/go-yamux/v4 v4.0.1 // indirect
-	github.com/matttproud/golang_protobuf_extensions/v2 v2.0.0 // indirect
-	github.com/onsi/ginkgo/v2 v2.13.0 // indirect
-	github.com/outcaste-io/ristretto v0.2.3 // indirect
-	github.com/quic-go/qpack v0.4.0 // indirect
-	github.com/quic-go/qtls-go1-20 v0.3.4 // indirect
-	github.com/quic-go/quic-go v0.39.3 // indirect
-	github.com/quic-go/webtransport-go v0.6.0 // indirect
-	github.com/richardartoul/molecule v1.0.1-0.20221107223329-32cfee06a052 // indirect
-	github.com/secure-systems-lab/go-securesystemslib v0.7.0 // indirect
-	go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc v0.49.0 // indirect
-	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.49.0 // indirect
-	go.opentelemetry.io/otel v1.24.0 // indirect
-	go.opentelemetry.io/otel/metric v1.24.0 // indirect
-	go.opentelemetry.io/otel/trace v1.24.0 // indirect
-	go.uber.org/dig v1.17.1 // indirect
-	go.uber.org/fx v1.20.1 // indirect
-	go.uber.org/mock v0.3.0 // indirect
-	golang.org/x/exp v0.0.0-20231006140011-7918f672742d // indirect
-	google.golang.org/genproto/googleapis/api v0.0.0-20240429193739-8cf5692501f6 // indirect
-	google.golang.org/genproto/googleapis/rpc v0.0.0-20240429193739-8cf5692501f6 // indirect
-)
-
-require (
 	cloud.google.com/go/iam v1.1.7 // indirect
 	filippo.io/edwards25519 v1.0.0-rc.1 // indirect
 	github.com/Azure/go-ansiterm v0.0.0-20210617225240-d185dfc1b5a1 // indirect
+	github.com/DataDog/appsec-internal-go v1.5.0 // indirect
 	github.com/DataDog/datadog-agent/pkg/obfuscate v0.48.0 // indirect
+	github.com/DataDog/datadog-agent/pkg/remoteconfig/state v0.48.1 // indirect
 	github.com/DataDog/datadog-go/v5 v5.3.0 // indirect
+	github.com/DataDog/go-libddwaf/v2 v2.4.2 // indirect
+	github.com/DataDog/go-tuf v1.0.2-0.5.2 // indirect
 	github.com/DataDog/gostackparse v0.7.0 // indirect
 	github.com/DataDog/sketches-go v1.4.2 // indirect
 	github.com/Microsoft/go-winio v0.6.1 // indirect
 	github.com/Nvveen/Gotty v0.0.0-20120604004816-cd527374f1e5 // indirect
 	github.com/andybalholm/brotli v1.0.6 // indirect
+	github.com/benbjohnson/clock v1.3.5 // indirect
 	github.com/beorn7/perks v1.0.1 // indirect
 	github.com/btcsuite/btcd/chaincfg/chainhash v1.0.1 // indirect
 	github.com/btcsuite/btcutil v1.0.3-0.20201208143702-a53e38424cce // indirect
@@ -133,6 +79,7 @@ require (
 	github.com/cenkalti/backoff/v3 v3.2.2 // indirect
 	github.com/cespare/xxhash/v2 v2.2.0 // indirect
 	github.com/consensys/gnark-crypto v0.5.3 // indirect
+	github.com/containerd/cgroups v1.1.0 // indirect
 	github.com/containerd/continuity v0.3.0 // indirect
 	github.com/coreos/go-systemd/v22 v22.5.0 // indirect
 	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc // indirect
@@ -141,17 +88,26 @@ require (
 	github.com/docker/distribution v2.8.2+incompatible // indirect
 	github.com/docker/go-units v0.5.0 // indirect
 	github.com/dustin/go-humanize v1.0.1 // indirect
+	github.com/ebitengine/purego v0.6.0-alpha.5 // indirect
+	github.com/elastic/gosigar v0.14.2 // indirect
+	github.com/fatih/color v1.15.0 // indirect
+	github.com/felixge/httpsnoop v1.0.4 // indirect
 	github.com/flynn/noise v1.0.0 // indirect
 	github.com/francoispqt/gojay v1.2.13 // indirect
+	github.com/go-jose/go-jose/v3 v3.0.1 // indirect
+	github.com/go-logr/logr v1.4.1 // indirect
+	github.com/go-logr/stdr v1.2.2 // indirect
 	github.com/go-task/slim-sprig v0.0.0-20230315185526-52ccab3ef572 // indirect
 	github.com/go-toolsmith/astcopy v1.0.2 // indirect
 	github.com/go-toolsmith/astequal v1.0.3 // indirect
+	github.com/godbus/dbus/v5 v5.1.0 // indirect
 	github.com/gogo/protobuf v1.3.2 // indirect
 	github.com/golang/groupcache v0.0.0-20210331224755-41bb18bfe9da // indirect
 	github.com/golang/snappy v0.0.4 // indirect
 	github.com/google/gofuzz v1.2.0 // indirect
 	github.com/google/gopacket v1.1.19 // indirect
 	github.com/google/pprof v0.0.0-20231023181126-ff6d637d2a7b // indirect
+	github.com/google/s2a-go v0.1.7 // indirect
 	github.com/googleapis/enterprise-certificate-proxy v0.3.2 // indirect
 	github.com/googleapis/gax-go/v2 v2.12.3 // indirect
 	github.com/hashicorp/errwrap v1.1.0 // indirect
@@ -161,13 +117,17 @@ require (
 	github.com/hashicorp/go-secure-stdlib/parseutil v0.1.7 // indirect
 	github.com/hashicorp/go-secure-stdlib/strutil v0.1.2 // indirect
 	github.com/hashicorp/go-sockaddr v1.0.2 // indirect
+	github.com/hashicorp/golang-lru/v2 v2.0.5 // indirect
 	github.com/huin/goupnp v1.3.0 // indirect
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
+	github.com/ipfs/boxo v0.8.1 // indirect
+	github.com/ipfs/go-cid v0.4.1 // indirect
 	github.com/ipfs/go-log v1.0.5 // indirect
 	github.com/ipfs/go-log/v2 v2.5.1 // indirect
 	github.com/jackpal/go-nat-pmp v1.0.2 // indirect
 	github.com/jbenet/go-temp-err-catcher v0.1.0 // indirect
 	github.com/jmespath/go-jmespath v0.4.0 // indirect
+	github.com/klauspost/compress v1.17.2 // indirect
 	github.com/klauspost/cpuid/v2 v2.2.6 // indirect
 	github.com/koron/go-ssdp v0.0.4 // indirect
 	github.com/libp2p/go-buffer-pool v0.1.0 // indirect
@@ -178,8 +138,12 @@ require (
 	github.com/libp2p/go-nat v0.2.0 // indirect
 	github.com/libp2p/go-netroute v0.2.1 // indirect
 	github.com/libp2p/go-reuseport v0.4.0 // indirect
+	github.com/libp2p/go-yamux/v4 v4.0.1 // indirect
 	github.com/marten-seemann/tcp v0.0.0-20210406111302-dfbc87cc63fd // indirect
+	github.com/mattn/go-colorable v0.1.13 // indirect
 	github.com/mattn/go-isatty v0.0.20 // indirect
+	github.com/matttproud/golang_protobuf_extensions/v2 v2.0.0 // indirect
+	github.com/miekg/dns v1.1.56 // indirect
 	github.com/mikioh/tcpinfo v0.0.0-20190314235526-30a79bb1804b // indirect
 	github.com/mikioh/tcpopt v0.0.0-20190314235656-172688c1accc // indirect
 	github.com/minio/sha256-simd v1.0.1 // indirect
@@ -187,19 +151,23 @@ require (
 	github.com/moby/term v0.0.0-20220808134915-39b0c02b01ae // indirect
 	github.com/morikuni/aec v1.0.0 // indirect
 	github.com/mr-tron/base58 v1.2.0 // indirect
+	github.com/multiformats/go-base32 v0.1.0 // indirect
 	github.com/multiformats/go-base36 v0.2.0 // indirect
 	github.com/multiformats/go-multiaddr-dns v0.3.1 // indirect
 	github.com/multiformats/go-multiaddr-fmt v0.1.0 // indirect
 	github.com/multiformats/go-multibase v0.2.0 // indirect
 	github.com/multiformats/go-multicodec v0.9.0 // indirect
+	github.com/multiformats/go-multihash v0.2.3 // indirect
 	github.com/multiformats/go-multistream v0.5.0 // indirect
 	github.com/multiformats/go-varint v0.0.7 // indirect
+	github.com/onsi/ginkgo/v2 v2.13.0 // indirect
 	github.com/opencontainers/go-digest v1.0.0 // indirect
 	github.com/opencontainers/image-spec v1.0.2 // indirect
 	github.com/opencontainers/runc v1.1.5 // indirect
 	github.com/opencontainers/runtime-spec v1.1.0 // indirect
 	github.com/opentracing/opentracing-go v1.2.0 // indirect
 	github.com/ory/dockertest v3.3.5+incompatible // indirect
+	github.com/outcaste-io/ristretto v0.2.3 // indirect
 	github.com/pbnjay/memory v0.0.0-20210728143218-7b4eea64cf58 // indirect
 	github.com/philhofer/fwd v1.1.2 // indirect
 	github.com/pkg/errors v0.9.1 // indirect
@@ -209,27 +177,47 @@ require (
 	github.com/prometheus/procfs v0.12.0 // indirect
 	github.com/quasilyte/gogrep v0.5.0 // indirect
 	github.com/quasilyte/stdinfo v0.0.0-20220114132959-f7386bf02567 // indirect
+	github.com/quic-go/qpack v0.4.0 // indirect
+	github.com/quic-go/qtls-go1-20 v0.3.4 // indirect
+	github.com/quic-go/quic-go v0.39.3 // indirect
+	github.com/quic-go/webtransport-go v0.6.0 // indirect
 	github.com/raulk/go-watchdog v1.3.0 // indirect
+	github.com/richardartoul/molecule v1.0.1-0.20221107223329-32cfee06a052 // indirect
 	github.com/ryanuber/go-glob v1.0.0 // indirect
+	github.com/secure-systems-lab/go-securesystemslib v0.7.0 // indirect
 	github.com/sirupsen/logrus v1.9.3 // indirect
 	github.com/spaolacci/murmur3 v1.1.0 // indirect
 	github.com/spf13/pflag v1.0.5 // indirect
 	github.com/stretchr/objx v0.5.2 // indirect
 	github.com/tinylib/msgp v1.1.8 // indirect
-	github.com/trailofbits/go-fuzz-utils v0.0.0-20210901195358-9657fcfd256c
 	github.com/tyler-smith/go-bip39 v1.1.0 // indirect
 	github.com/valyala/bytebufferpool v1.0.0 // indirect
 	github.com/valyala/fasthttp v1.51.0 // indirect
+	github.com/valyala/fastjson v1.6.3 // indirect
 	go.opencensus.io v0.24.0 // indirect
+	go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc v0.49.0 // indirect
+	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.49.0 // indirect
+	go.opentelemetry.io/otel v1.24.0 // indirect
+	go.opentelemetry.io/otel/metric v1.24.0 // indirect
+	go.opentelemetry.io/otel/trace v1.24.0 // indirect
 	go.uber.org/atomic v1.11.0 // indirect
+	go.uber.org/dig v1.17.1 // indirect
+	go.uber.org/fx v1.20.1 // indirect
+	go.uber.org/mock v0.3.0 // indirect
 	go.uber.org/multierr v1.11.0 // indirect
+	go.uber.org/zap v1.26.0 // indirect
+	golang.org/x/exp v0.0.0-20231006140011-7918f672742d // indirect
 	golang.org/x/exp/typeparams v0.0.0-20230307190834-24139beb5833 // indirect
 	golang.org/x/mod v0.14.0 // indirect
 	golang.org/x/net v0.24.0 // indirect
 	golang.org/x/oauth2 v0.19.0 // indirect
+	golang.org/x/sys v0.19.0 // indirect
 	golang.org/x/text v0.14.0 // indirect
 	golang.org/x/time v0.5.0 // indirect
 	golang.org/x/xerrors v0.0.0-20220907171357-04be3eba64a2 // indirect
 	google.golang.org/api v0.177.0 // indirect
+	google.golang.org/genproto/googleapis/api v0.0.0-20240429193739-8cf5692501f6 // indirect
+	google.golang.org/genproto/googleapis/rpc v0.0.0-20240429193739-8cf5692501f6 // indirect
 	gotest.tools/v3 v3.0.2 // indirect
+	lukechampine.com/blake3 v1.2.1 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -3,6 +3,7 @@ cloud.google.com/go v0.31.0/go.mod h1:aQUYkXzVsufM+DwF1aE+0xfcU+56JwCaLick0ClmMT
 cloud.google.com/go v0.34.0/go.mod h1:aQUYkXzVsufM+DwF1aE+0xfcU+56JwCaLick0ClmMTw=
 cloud.google.com/go v0.37.0/go.mod h1:TS1dMSSfndXH133OKGwekG838Om/cQT0BUHV3HcBgoo=
 cloud.google.com/go v0.112.2 h1:ZaGT6LiG7dBzi6zNOvVZwacaXlmf3lRqnC4DQzqyRQw=
+cloud.google.com/go v0.112.2/go.mod h1:iEqjp//KquGIJV/m+Pk3xecgKNhV+ry+vVTsy4TbDms=
 cloud.google.com/go/auth v0.3.0 h1:PRyzEpGfx/Z9e8+lHsbkoUVXD0gnu4MNmm7Gp8TQNIs=
 cloud.google.com/go/auth v0.3.0/go.mod h1:lBv6NKTWp8E3LPzmO1TbiiRKc4drLOfHsgmlH9ogv5w=
 cloud.google.com/go/auth/oauth2adapt v0.2.2 h1:+TTV8aXpjeChS9M+aTtN/TjdQnzJvmzKFt//oWu7HX4=
@@ -134,6 +135,7 @@ github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc/go.mod h1:J7Y8Yc
 github.com/davidlazar/go-crypto v0.0.0-20200604182044-b73af7476f6c h1:pFUpOrbxDR6AkioZ1ySsx5yxlDQZ8stG2b88gTPxgJU=
 github.com/davidlazar/go-crypto v0.0.0-20200604182044-b73af7476f6c/go.mod h1:6UhI8N9EjYm1c2odKpFpAYeR8dsBeM7PtzQhRgxRr9U=
 github.com/decred/dcrd/crypto/blake256 v1.0.1 h1:7PltbUIQB7u/FfZ39+DGa/ShuMyJ5ilcvdfma9wOH6Y=
+github.com/decred/dcrd/crypto/blake256 v1.0.1/go.mod h1:2OfgNZ5wDpcsFmHmCK5gZTPcCXqlm2ArzUIkw9czNJo=
 github.com/decred/dcrd/dcrec/secp256k1/v4 v4.2.0 h1:8UrgZ3GkP4i/CLijOJx79Yu+etlyjdBU4sfcs2WYQMs=
 github.com/decred/dcrd/dcrec/secp256k1/v4 v4.2.0/go.mod h1:v57UDF4pDQJcEfFUCRop3lJL149eHGSe9Jvczhzjo/0=
 github.com/dgryski/go-farm v0.0.0-20190423205320-6a90982ecee2 h1:tdlZCpZ/P9DhczCTSixgIKmwPv6+wP5DGjqLYw5SUiA=
@@ -177,6 +179,7 @@ github.com/fsnotify/fsnotify v1.4.7/go.mod h1:jwhsz4b93w/PPRr/qN1Yymfu8t87LnFCMo
 github.com/fsnotify/fsnotify v1.4.9/go.mod h1:znqG4EE+3YCdAaPaxE2ZRY/06pZUdp0tY4IgpuI1SZQ=
 github.com/fsnotify/fsnotify v1.5.4/go.mod h1:OVB6XrOHzAwXMpEM7uPOzcehqUV2UqJxmVXmkdnm1bU=
 github.com/fsnotify/fsnotify v1.6.0 h1:n+5WquG0fcWoWp6xPWfHdbskMCQaFnG6PfBrh1Ky4HY=
+github.com/fsnotify/fsnotify v1.6.0/go.mod h1:sl3t1tCWJFWoRz9R8WJCbQihKKwmorjAbSClcnxKAGw=
 github.com/ghodss/yaml v1.0.0/go.mod h1:4dBDuWmgqj2HViK6kFavaiC9ZROes6MMH2rRYeMEF04=
 github.com/gliderlabs/ssh v0.1.1/go.mod h1:U7qILu1NlMHj9FlMhZLlkCdDnU1DBEAqr0aevW3Awn0=
 github.com/go-errors/errors v1.0.1/go.mod h1:f4zRHt4oKfwPJE5k8C9vpYG+aDHdBFUsgrm6/TyX73Q=
@@ -196,6 +199,7 @@ github.com/go-task/slim-sprig v0.0.0-20210107165309-348f09dbbbc0/go.mod h1:fyg78
 github.com/go-task/slim-sprig v0.0.0-20230315185526-52ccab3ef572 h1:tfuBGBXKqDEevZMzYi5KSi8KkcZtzBcTgAUUtapy0OI=
 github.com/go-task/slim-sprig v0.0.0-20230315185526-52ccab3ef572/go.mod h1:9Pwr4B2jHnOSGXyyzV8ROjYa2ojvAY6HCGYYfMoC3Ls=
 github.com/go-test/deep v1.0.2 h1:onZX1rnHT3Wv6cqNgYyFOOlgVKJrksuCMCRvJStbMYw=
+github.com/go-test/deep v1.0.2/go.mod h1:wGDj63lr65AM2AQyKZd/NYHGb0R+1RLqB8NKt3aSFNA=
 github.com/go-toolsmith/astcopy v1.0.2 h1:YnWf5Rnh1hUudj11kei53kI57quN/VH6Hp1n+erozn0=
 github.com/go-toolsmith/astcopy v1.0.2/go.mod h1:4TcEdbElGc9twQEYpVo/aieIXfHhiuLh4aLAck6dO7Y=
 github.com/go-toolsmith/astequal v1.0.2/go.mod h1:9Ai4UglvtR+4up+bAD4+hCj7iTo4m/OXVTSLnCyTAx4=
@@ -249,6 +253,7 @@ github.com/google/go-cmp v0.5.4/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/
 github.com/google/go-cmp v0.5.5/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.5.8/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
 github.com/google/go-cmp v0.6.0 h1:ofyhxvXcZhMsU5ulbFiLKl/XBFqE1GSq7atu8tAmTRI=
+github.com/google/go-cmp v0.6.0/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
 github.com/google/go-github v17.0.0+incompatible/go.mod h1:zLgOLi98H3fifZn+44m+umXrS52loVEgC2AApnigrVQ=
 github.com/google/go-querystring v1.0.0/go.mod h1:odCYkC5MyYFN7vkCjXpyrEuKhc/BUO6wN/zVPAxq5ck=
 github.com/google/gofuzz v1.0.0/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/M65Eg=
@@ -278,6 +283,7 @@ github.com/gopherjs/gopherjs v0.0.0-20181017120253-0766667cb4d1/go.mod h1:wJfORR
 github.com/gorilla/websocket v1.5.1 h1:gmztn0JnHVt9JZquRuzLw3g4wouNVzKL15iLr/zn/QY=
 github.com/gorilla/websocket v1.5.1/go.mod h1:x3kM2JMyaluk02fnUJpQuwD2dCS5NDG2ZHL0uE0tcaY=
 github.com/gotestyourself/gotestyourself v2.2.0+incompatible h1:AQwinXlbQR2HvPjQZOmDhRqsv5mZf+Jb1RnSLxcqZcI=
+github.com/gotestyourself/gotestyourself v2.2.0+incompatible/go.mod h1:zZKM6oeNM8k+FRljX1mnzVYeS8wiGgQyvST1/GafPbY=
 github.com/gregjones/httpcache v0.0.0-20180305231024-9cad4c3443a7/go.mod h1:FecbI9+v66THATjSRHfNgh1IVFe/9kFxbXtjV0ctIMA=
 github.com/grpc-ecosystem/grpc-gateway v1.5.0/go.mod h1:RSKVYQBd5MCa4OVpNdGskqpgL2+G+NZTnrVHpWWfpdw=
 github.com/hashicorp/errwrap v1.0.0/go.mod h1:YH+1FKiLXxHSkmPseP+kNlulaMuP3n2brvKWEqk/Jc4=
@@ -309,6 +315,7 @@ github.com/hashicorp/go-sockaddr v1.0.2 h1:ztczhD1jLxIRjVejw8gFomI1BQZOe2WoVOu0S
 github.com/hashicorp/go-sockaddr v1.0.2/go.mod h1:rB4wwRAUzs07qva3c5SdrY/NEtAUjGlgmH/UkBUC97A=
 github.com/hashicorp/go-uuid v1.0.0/go.mod h1:6SBZvOh/SIDV7/2o3Jml5SYk/TvGqwFJ/bN7x4byOro=
 github.com/hashicorp/go-uuid v1.0.3 h1:2gKiV6YVmrJ1i2CKKa9obLvRieoRGviZFL26PcT/Co8=
+github.com/hashicorp/go-uuid v1.0.3/go.mod h1:6SBZvOh/SIDV7/2o3Jml5SYk/TvGqwFJ/bN7x4byOro=
 github.com/hashicorp/golang-lru v0.5.0/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ4Ao+sR/qLZy8=
 github.com/hashicorp/golang-lru v1.0.2 h1:dV3g9Z/unq5DpblPpw+Oqcv4dU/1omnb4Ok8iPY6p1c=
 github.com/hashicorp/golang-lru v1.0.2/go.mod h1:iADmTwqILo4mZ8BN3D2Q6+9jd8WM5uGBxy+E8yxSoD4=
@@ -365,13 +372,16 @@ github.com/kr/logfmt v0.0.0-20140226030751-b84e30acd515/go.mod h1:+0opPa2QZZtGFB
 github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORNo=
 github.com/kr/pretty v0.2.1/go.mod h1:ipq/a2n7PKx3OHsz4KJII5eveXtPO4qwEXGdVfWzfnI=
 github.com/kr/pretty v0.3.1 h1:flRD4NNwYAUpkphVc1HcthR4KEIFJ65n8Mw5qdRn3LE=
+github.com/kr/pretty v0.3.1/go.mod h1:hoEshYVHaxMs3cyo3Yncou5ZscifuDolrwPKZanG3xk=
 github.com/kr/pty v1.1.1/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=
 github.com/kr/pty v1.1.3/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=
 github.com/kr/text v0.1.0/go.mod h1:4Jbv+DJW3UT/LiOwJeYQe1efqtUx/iVham/4vfdArNI=
 github.com/kr/text v0.2.0 h1:5Nx0Ya0ZqY2ygV366QzturHI13Jq95ApcVaJBhpS+AY=
+github.com/kr/text v0.2.0/go.mod h1:eLer722TekiGuMkidMxC/pM04lWEeraHUUmBw8l2grE=
 github.com/leanovate/gopter v0.2.9 h1:fQjYxZaynp97ozCzfOyOuAGOU4aU/z37zf/tOujFk7c=
 github.com/leanovate/gopter v0.2.9/go.mod h1:U2L/78B+KVFIx2VmW6onHJQzXtFb+p5y3y2Sh+Jxxv8=
 github.com/lib/pq v1.10.2 h1:AqzbZs4ZoCBp+GtejcpCpcxM3zlSMx29dXbUSeVtJb8=
+github.com/lib/pq v1.10.2/go.mod h1:AlVN5x4E4T544tWzH6hKfbfQvm3HdbOxrmggDNAPY9o=
 github.com/libp2p/go-buffer-pool v0.1.0 h1:oK4mSFcQz7cTQIfqbe4MIj9gLW+mnanjyFtc6cdF0Y8=
 github.com/libp2p/go-buffer-pool v0.1.0/go.mod h1:N+vh8gMqimBzdKkSMVuydVDq+UV5QTWy5HSiZacSbPg=
 github.com/libp2p/go-cidranger v1.1.0 h1:ewPN8EZ0dd1LSnrtuwd4709PXVcITVeuwbag38yPW7c=
@@ -387,6 +397,7 @@ github.com/libp2p/go-libp2p-kbucket v0.6.3/go.mod h1:RCseT7AH6eJWxxk2ol03xtP9pEH
 github.com/libp2p/go-libp2p-pubsub v0.10.1 h1:/RqOZpEtAolsr8/9CC8KqROJSOZeu7lK7fPftn4MwNg=
 github.com/libp2p/go-libp2p-pubsub v0.10.1/go.mod h1:1OxbaT/pFRO5h+Dpze8hdHQ63R0ke55XTs6b6NwLLkw=
 github.com/libp2p/go-libp2p-testing v0.12.0 h1:EPvBb4kKMWO29qP4mZGyhVzUyR25dvfUIK5WDu6iPUA=
+github.com/libp2p/go-libp2p-testing v0.12.0/go.mod h1:KcGDRXyN7sQCllucn1cOOS+Dmm7ujhfEyXQL5lvkcPg=
 github.com/libp2p/go-msgio v0.3.0 h1:mf3Z8B1xcFN314sWX+2vOTShIE0Mmn2TXn3YCUQGNj0=
 github.com/libp2p/go-msgio v0.3.0/go.mod h1:nyRM819GmVaF9LX3l03RMh10QdOroF++NBbxAb0mmDM=
 github.com/libp2p/go-nat v0.2.0 h1:Tyz+bUFAYqGyJ/ppPPymMGbIgNRH+WqC5QrT5fKrrGk=
@@ -494,6 +505,7 @@ github.com/onsi/gomega v1.10.1/go.mod h1:iN09h71vgCQne3DLsj+A5owkum+a2tYe+TOCB1y
 github.com/onsi/gomega v1.17.0/go.mod h1:HnhC7FXeEQY45zxNK3PPoIUhzk/80Xly9PcubAlGdZY=
 github.com/onsi/gomega v1.19.0/go.mod h1:LY+I3pBVzYsTBU1AnDwOSxaYi9WoWiqgwooUqq9yPro=
 github.com/onsi/gomega v1.27.10 h1:naR28SdDFlqrG6kScpT8VWpu1xWY5nJRCF3XaYyBjhI=
+github.com/onsi/gomega v1.27.10/go.mod h1:RsS8tutOdbdgzbPtzzATp12yT7kM5I5aElG3evPbQ0M=
 github.com/opencontainers/go-digest v1.0.0 h1:apOUWs51W5PlhuyGyz9FCeeBIOUDA/6nW8Oi/yOhh5U=
 github.com/opencontainers/go-digest v1.0.0/go.mod h1:0JzlMkj0TRzQZfJkVvzbP0HBR3IKzErnv2BNG4W4MAM=
 github.com/opencontainers/image-spec v1.0.2 h1:9yCKha/T5XdGtO0q9Q9a6T5NUCsTn/DrBg0D7ufOcFM=
@@ -571,6 +583,7 @@ github.com/richardartoul/molecule v1.0.1-0.20221107223329-32cfee06a052 h1:Qp27Id
 github.com/richardartoul/molecule v1.0.1-0.20221107223329-32cfee06a052/go.mod h1:uvX/8buq8uVeiZiFht+0lqSLBHF+uGV8BrTv8W/SIwk=
 github.com/rogpeppe/go-internal v1.3.0/go.mod h1:M8bDsm7K2OlrFYOpmOWEs/qY81heoFRclV5y23lUDJ4=
 github.com/rogpeppe/go-internal v1.10.0 h1:TMyTOH3F/DB16zRVcYyreMH6GnZZrwQVAoYjRBZyWFQ=
+github.com/rogpeppe/go-internal v1.10.0/go.mod h1:UQnix2H7Ngw/k4C5ijL5+65zddjncjaFoBhdsK/akog=
 github.com/russross/blackfriday v1.5.2/go.mod h1:JO/DiYxRf+HjHt06OyowR9PTA263kcR/rfWxYHBV53g=
 github.com/russross/blackfriday/v2 v2.0.1/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
 github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
@@ -688,6 +701,7 @@ go.opentelemetry.io/otel v1.24.0/go.mod h1:W7b9Ozg4nkF5tWI5zsXkaKKDjdVjpD4oAt9Qi
 go.opentelemetry.io/otel/metric v1.24.0 h1:6EhoGWWK28x1fbpA4tYTOWBkPefTDQnb8WSGXlc88kI=
 go.opentelemetry.io/otel/metric v1.24.0/go.mod h1:VYhLe1rFfxuTXLgj4CBiyz+9WYBA8pNGJgDcSFRKBco=
 go.opentelemetry.io/otel/sdk v1.24.0 h1:YMPPDNymmQN3ZgczicBY3B6sf9n62Dlj9pWD3ucgoDw=
+go.opentelemetry.io/otel/sdk v1.24.0/go.mod h1:KVrIYw6tEubO9E96HQpcmpTKDVn9gdv35HoYiQWGDFg=
 go.opentelemetry.io/otel/trace v1.24.0 h1:CsKnnL4dUAr/0llH9FKuc698G04IrpWV0MQA/Y1YELI=
 go.opentelemetry.io/otel/trace v1.24.0/go.mod h1:HPc3Xr/cOApsBI154IU0OI0HJexz+aw5uPdbs3UCjNU=
 go.uber.org/atomic v1.6.0/go.mod h1:sABNBOSYdrvTF6hTgEIbc7YasKWGhgEQZyfxyTvoXHQ=
@@ -701,6 +715,7 @@ go.uber.org/fx v1.20.1 h1:zVwVQGS8zYvhh9Xxcu4w1M6ESyeMzebzj2NbSayZ4Mk=
 go.uber.org/fx v1.20.1/go.mod h1:iSYNbHf2y55acNCwCXKx7LbWb5WG1Bnue5RDXz1OREg=
 go.uber.org/goleak v1.1.11-0.20210813005559-691160354723/go.mod h1:cwTWslyiVhfpKIDGSZEM2HlOvcqm+tG4zioyIeLoqMQ=
 go.uber.org/goleak v1.3.0 h1:2K3zAYmnTNqV73imy9J1T3WC+gmCePx2hEGkimedGto=
+go.uber.org/goleak v1.3.0/go.mod h1:CoHD4mav9JJNrW/WLlf7HGZPjdw8EucARQHekz1X6bE=
 go.uber.org/mock v0.3.0 h1:3mUxI1No2/60yUYax92Pt8eNOEecx2D3lcXZh2NEZJo=
 go.uber.org/mock v0.3.0/go.mod h1:a6FSlNadKUHUa9IP5Vyt1zh4fC7uAwxMutEAscFbkZc=
 go.uber.org/multierr v1.5.0/go.mod h1:FeouvMocqHpRaaGuG9EjoKcStLC43Zu/fmqdUMPcKYU=
@@ -978,6 +993,7 @@ gotest.tools/v3 v3.0.2 h1:kG1BFyqVHuQoVQiR1bWGnfz/fmHvvuiSPIV7rvl360E=
 gotest.tools/v3 v3.0.2/go.mod h1:3SzNCllyD9/Y+b5r9JIKQ474KzkZyqLqEfYqMsX94Bk=
 grpc.go4.org v0.0.0-20170609214715-11d0a25b4919/go.mod h1:77eQGdRu53HpSqPFJFmuJdjuHRquDANNeA4x7B8WQ9o=
 honnef.co/go/gotraceui v0.2.0 h1:dmNsfQ9Vl3GwbiVD7Z8d/osC6WtGGrasyrC2suc4ZIQ=
+honnef.co/go/gotraceui v0.2.0/go.mod h1:qHo4/W75cA3bX0QQoSvDjbJa4R8mAyyFjbWAj63XElc=
 honnef.co/go/tools v0.0.0-20180728063816-88497007e858/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=
 honnef.co/go/tools v0.0.0-20190102054323-c2f93a96b099/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=
 honnef.co/go/tools v0.0.0-20190106161140-3f1c8253044a/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=

--- a/helper/common/common_test.go
+++ b/helper/common/common_test.go
@@ -38,6 +38,7 @@ func Test_ExtendByteSlice(t *testing.T) {
 
 			newSlice := ExtendByteSlice(originalSlice, c.newLength)
 			require.Len(t, newSlice, c.newLength)
+
 			if c.length > c.newLength {
 				require.Equal(t, originalSlice[:c.newLength], newSlice)
 			} else {
@@ -98,6 +99,7 @@ func Test_Duration_Marshal_UnmarshalJSON(t *testing.T) {
 		require.NoError(t, err)
 
 		var otherTimer *timer
+
 		require.NoError(t, json.Unmarshal(timerRaw, &otherTimer))
 		require.Equal(t, origTimer, otherTimer)
 	})

--- a/jsonrpc/codec_test.go
+++ b/jsonrpc/codec_test.go
@@ -105,9 +105,11 @@ func TestBlockNumberOrHash_UnmarshalJSON(t *testing.T) {
 				assert.Error(t, err)
 			} else {
 				assert.NoError(t, err)
+
 				if tt.expectedBnh.BlockNumber != nil {
 					assert.Equal(t, *bnh.BlockNumber, *tt.expectedBnh.BlockNumber)
 				}
+
 				if tt.expectedBnh.BlockHash != nil {
 					assert.Equal(t, bnh.BlockHash.String(), tt.expectedBnh.BlockHash.String())
 				}

--- a/jsonrpc/dispatcher.go
+++ b/jsonrpc/dispatcher.go
@@ -200,17 +200,18 @@ func (d *Dispatcher) handleSubscribe(req Request, conn wsConn) (string, Error) {
 	}
 
 	var filterID string
-	if subscribeMethod == "newHeads" {
+	switch subscribeMethod {
+	case "newHeads":
 		filterID = d.filterManager.NewBlockFilter(conn)
-	} else if subscribeMethod == "logs" {
+	case "logs":
 		logQuery, err := decodeLogQueryFromInterface(params[1])
 		if err != nil {
 			return "", NewInternalError(err.Error())
 		}
 		filterID = d.filterManager.NewLogFilter(logQuery, conn)
-	} else if subscribeMethod == "newPendingTransactions" {
+	case "newPendingTransactions":
 		filterID = d.filterManager.NewPendingTxFilter(conn)
-	} else {
+	default:
 		return "", NewSubscriptionNotFoundError(subscribeMethod)
 	}
 

--- a/jsonrpc/dispatcher.go
+++ b/jsonrpc/dispatcher.go
@@ -200,6 +200,7 @@ func (d *Dispatcher) handleSubscribe(req Request, conn wsConn) (string, Error) {
 	}
 
 	var filterID string
+
 	switch subscribeMethod {
 	case "newHeads":
 		filterID = d.filterManager.NewBlockFilter(conn)
@@ -208,6 +209,7 @@ func (d *Dispatcher) handleSubscribe(req Request, conn wsConn) (string, Error) {
 		if err != nil {
 			return "", NewInternalError(err.Error())
 		}
+
 		filterID = d.filterManager.NewLogFilter(logQuery, conn)
 	case "newPendingTransactions":
 		filterID = d.filterManager.NewPendingTxFilter(conn)

--- a/jsonrpc/dispatcher_test.go
+++ b/jsonrpc/dispatcher_test.go
@@ -469,20 +469,24 @@ func TestDispatcherBatchRequest(t *testing.T) {
 			assert.Equal(t, c.err, resp.Error)
 		} else {
 			var batchResp []SuccessResponse
+
 			assert.NoError(t, expectBatchJSONResult(res, &batchResp))
 
 			if c.name == "leading-whitespace" {
 				assert.Len(t, batchResp, 4)
+
 				for index, resp := range batchResp {
 					assert.Equal(t, c.batchResponse[index].Error, resp.Error)
 				}
 			} else if c.name == "valid-batch-req" {
 				assert.Len(t, batchResp, 6)
+
 				for index, resp := range batchResp {
 					assert.Equal(t, c.batchResponse[index].Error, resp.Error)
 				}
 			} else if c.name == "no-limits" {
 				assert.Len(t, batchResp, 12)
+
 				for index, resp := range batchResp {
 					assert.Equal(t, c.batchResponse[index].Error, resp.Error)
 				}

--- a/jsonrpc/eth_blockchain_test.go
+++ b/jsonrpc/eth_blockchain_test.go
@@ -90,6 +90,7 @@ func TestEth_Block_GetBlockTransactionCountByNumber(t *testing.T) {
 	for i := 0; i < 10; i++ {
 		block.Transactions = append(block.Transactions, []*types.Transaction{{Nonce: 0, From: addr0}}...)
 	}
+
 	store.add(block)
 
 	eth := newTestEthEndpoint(store)
@@ -191,6 +192,7 @@ func TestEth_GetTransactionReceipt(t *testing.T) {
 		eth := newTestEthEndpoint(store)
 		block := newTestBlock(1, hash4)
 		store.add(block)
+
 		txn0 := newTestTransaction(uint64(0), addr0)
 		txn1 := newTestTransaction(uint64(1), addr1)
 		block.Transactions = []*types.Transaction{txn0, txn1}
@@ -216,7 +218,9 @@ func TestEth_GetTransactionReceipt(t *testing.T) {
 				},
 			},
 		}
+
 		receipt1.SetStatus(types.ReceiptSuccess)
+
 		receipt2 := &types.Receipt{
 			Logs: []*types.Log{
 				{
@@ -228,6 +232,7 @@ func TestEth_GetTransactionReceipt(t *testing.T) {
 			},
 		}
 		receipt2.SetStatus(types.ReceiptSuccess)
+
 		store.receipts[hash4] = []*types.Receipt{receipt1, receipt2}
 
 		res, err := eth.GetTransactionReceipt(txn1.Hash)

--- a/jsonrpc/eth_state_test.go
+++ b/jsonrpc/eth_state_test.go
@@ -131,6 +131,7 @@ func TestEth_State_GetBalance(t *testing.T) {
 				assert.Equal(t, nil, balance)
 			} else {
 				assert.NoError(t, err)
+
 				if tt.expectedBalance == 0 {
 					uintBalance, ok := balance.(*argUint64)
 					if !ok {
@@ -383,6 +384,7 @@ func TestEth_State_GetCode(t *testing.T) {
 				assert.Error(t, err)
 			} else {
 				assert.NoError(t, err)
+
 				if tt.target.String() == uninitializedAddress.String() {
 					assert.Equal(t, "0x", code)
 				} else {
@@ -552,7 +554,9 @@ func TestEth_State_GetStorageAt(t *testing.T) {
 					},
 					storage: make(map[types.Hash][]byte),
 				}
+
 				account := store.account
+
 				for index, data := range storage {
 					account.Storage(index, data.Bytes())
 				}

--- a/jsonrpc/filter_manager.go
+++ b/jsonrpc/filter_manager.go
@@ -903,7 +903,7 @@ func (t timeHeapImpl) Swap(i, j int) {
 
 func (t *timeHeapImpl) Push(x interface{}) {
 	n := len(*t)
-	item := x.(*filterBase) //nolint: forcetypeassert
+	item := x.(*filterBase) //nolint:forcetypeassert
 	item.heapIndex = n
 	*t = append(*t, item)
 }
@@ -973,6 +973,7 @@ func (h *headElem) getUpdates() ([]*block, *headElem) {
 			if nextElem.header != nil {
 				res = append(res, nextElem.header)
 			}
+
 			cur = nextElem
 		}
 	}

--- a/jsonrpc/filter_manager_fuzz_test.go
+++ b/jsonrpc/filter_manager_fuzz_test.go
@@ -90,6 +90,7 @@ func FuzzGetLogsForQuery(f *testing.F) {
 		if len(hash) != types.HashLength {
 			t.Skip()
 		}
+
 		blockHash := types.BytesToHash(hash)
 
 		logQuery := LogQuery{
@@ -145,11 +146,13 @@ func FuzzGetLogFilterFromID(f *testing.F) {
 		if len(address) != types.AddressLength {
 			t.Skip()
 		}
+
 		logFilter := &LogQuery{
 			Addresses: []types.Address{types.BytesToAddress(address)},
 			toBlock:   BlockNumber(toBlock),
 			fromBlock: BlockNumber(fromBlock),
 		}
+
 		retrivedLogFilter, err := m.GetLogFilterFromID(
 			m.NewLogFilter(logFilter, &MockClosedWSConnection{}),
 		)

--- a/jsonrpc/filter_manager_test.go
+++ b/jsonrpc/filter_manager_test.go
@@ -729,6 +729,7 @@ func TestHeadStream_Concurrent(t *testing.T) {
 
 						return
 					}
+
 					expect++
 
 					if expect == uint64(nMessages) {

--- a/jsonrpc/helper.go
+++ b/jsonrpc/helper.go
@@ -176,6 +176,7 @@ func DecodeTxn(arg *txnArgs, blockNumber uint64, store nonceGetter, forceSetNonc
 		if err != nil {
 			return nil, err
 		}
+
 		arg.Nonce = argUintPtr(nonce)
 	}
 

--- a/jsonrpc/jsonrpc.go
+++ b/jsonrpc/jsonrpc.go
@@ -158,6 +158,7 @@ func middlewareFactory(config *Config) func(http.Handler) http.Handler {
 					break
 				}
 			}
+
 			next.ServeHTTP(w, r)
 		})
 	}

--- a/jsonrpc/txpool_endpoint.go
+++ b/jsonrpc/txpool_endpoint.go
@@ -89,13 +89,13 @@ func (t *TxPool) Inspect() (interface{}, error) {
 	}
 
 	// get capacity of the TxPool
-	current, max := t.store.GetCapacity()
+	current, maximum := t.store.GetCapacity()
 	pendingTxs, queuedTxs := t.store.GetTxs(true)
 	resp := InspectResponse{
 		Pending:         convertTxMap(pendingTxs),
 		Queued:          convertTxMap(queuedTxs),
 		CurrentCapacity: current,
-		MaxCapacity:     max,
+		MaxCapacity:     maximum,
 	}
 
 	return resp, nil

--- a/network/common/common.go
+++ b/network/common/common.go
@@ -49,7 +49,6 @@ var (
 	// /ip6/<any loopback>/tcp/<port>
 	// /dns/foobar.com/tcp/<port>
 	loopbackRegex = regexp.MustCompile(
-		//nolint:lll
 		fmt.Sprintf(`^\/ip4\/127(?:\.[0-9]+){0,2}\.[0-9]+\/tcp\/\d+$|^\/ip4\/localhost\/tcp\/\d+$|^\/ip6\/(?:0*\:)*?:?0*1\/tcp\/\d+$|%s`, DNSRegex),
 	)
 

--- a/network/dial/dial_queue_test.go
+++ b/network/dial/dial_queue_test.go
@@ -161,6 +161,7 @@ func TestDel(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			q := NewDialQueue()
+
 			for _, task := range tt.tasks {
 				id := peer.ID(task.id)
 
@@ -178,6 +179,7 @@ func TestDel(t *testing.T) {
 					t.Errorf("unsupported action: %s", task.action)
 				}
 			}
+
 			assert.Equal(t, tt.expectedLen, q.heap.Len())
 		})
 	}

--- a/network/identity_e2e_test.go
+++ b/network/identity_e2e_test.go
@@ -44,6 +44,7 @@ func TestIdentityHandshake(t *testing.T) {
 					},
 				},
 			}
+
 			servers, createErr := createServers(2, params)
 			if createErr != nil {
 				t.Fatalf("Unable to create servers, %v", createErr)
@@ -63,6 +64,7 @@ func TestIdentityHandshake(t *testing.T) {
 			// Server 0 -> Server 1
 			joinTimeout := DefaultJoinTimeout
 			connectTimeout := DefaultBufferTimeout
+
 			if !shouldSucceed {
 				connectTimeout = time.Second * 5
 				joinTimeout = time.Second * 5

--- a/network/server_test.go
+++ b/network/server_test.go
@@ -187,6 +187,7 @@ func TestPeerEvent_EmitAndSubscribe(t *testing.T) {
 			id, event := getIDAndEventType(i)
 			server.emitEvent(id, event)
 		}
+
 		for i := 0; i < count; i++ {
 			received := <-receiver
 			id, event := getIDAndEventType(i)
@@ -653,6 +654,7 @@ func TestRunDial(t *testing.T) {
 				t.Fatalf("Unable to join peer, %v", joinErr)
 			}
 		}
+
 		closeServers(servers...)
 	})
 
@@ -673,6 +675,7 @@ func TestRunDial(t *testing.T) {
 				assert.Error(t, joinErr)
 			}
 		}
+
 		closeServers(servers...)
 	})
 
@@ -769,9 +772,8 @@ func TestSubscribe(t *testing.T) {
 		server := setupServer(t, true)
 
 		ctx, cancel := context.WithCancel(context.Background())
-		t.Cleanup(func() {
-			cancel()
-		})
+
+		t.Cleanup(cancel)
 
 		eventCh := toChannel(t, ctx, server)
 
@@ -808,9 +810,8 @@ func TestSubscribe(t *testing.T) {
 		server := setupServer(t, false)
 
 		ctx, cancel := context.WithCancel(context.Background())
-		t.Cleanup(func() {
-			cancel()
-		})
+
+		t.Cleanup(cancel)
 
 		eventCh := toChannel(t, ctx, server)
 
@@ -1107,6 +1108,7 @@ func TestPeerAdditionDeletion(t *testing.T) {
 		prunedPeers := 0
 		for i := 0; i < len(randomPeers); i += 2 {
 			prunedPeers++
+
 			server.removePeer(randomPeers[i].peerID)
 
 			assert.False(t, server.hasPeer(randomPeers[i].peerID))

--- a/price-oracle/mocks_test.go
+++ b/price-oracle/mocks_test.go
@@ -40,6 +40,7 @@ var _ blockchainBackend = (*MockBlockchainBackend)(nil)
 
 func (m *MockBlockchainBackend) CurrentHeader() *types.Header {
 	args := m.Called()
+
 	header, ok := args.Get(0).(*types.Header)
 	if !ok {
 		panic("Expected *types.Header but got a different type")
@@ -52,6 +53,7 @@ func (m *MockBlockchainBackend) GetStateProviderForBlock(
 	block *types.Header,
 ) (contract.Provider, error) {
 	args := m.Called(block)
+
 	provider, ok := args.Get(0).(contract.Provider)
 	if !ok {
 		panic("Expected contract.Provider but got a different type")
@@ -62,6 +64,7 @@ func (m *MockBlockchainBackend) GetStateProviderForBlock(
 
 func (m *MockBlockchainBackend) GetSystemState(provider contract.Provider) polybft.SystemState {
 	args := m.Called(provider)
+
 	state, ok := args.Get(0).(polybft.SystemState)
 	if !ok {
 		panic("Expected polybft.SystemState but got a different type")
@@ -72,6 +75,7 @@ func (m *MockBlockchainBackend) GetSystemState(provider contract.Provider) polyb
 
 func (m *MockBlockchainBackend) SubscribeEvents() blockchain.Subscription {
 	args := m.Called()
+
 	subsciption, ok := args.Get(0).(blockchain.Subscription)
 	if !ok {
 		panic("Expected blockchain.Subscription but got a different type")
@@ -93,6 +97,7 @@ func (m *MockPolybftBackend) GetValidators(
 	parents []*types.Header,
 ) (validator.AccountSet, error) {
 	args := m.Called(blockNumber, parents)
+
 	accSet, ok := args.Get(0).(validator.AccountSet)
 	if !ok {
 		panic("Expected validator.AccountSet but got a different type")
@@ -117,6 +122,7 @@ func (m *MockTxRelayer) SendTransaction(
 	key ethgo.Key,
 ) (*ethgo.Receipt, error) {
 	args := m.Called(txn, key)
+
 	receipt, ok := args.Get(0).(*ethgo.Receipt)
 	if !ok {
 		panic("Expected *ethgo.Receipt but got a different type")
@@ -127,6 +133,7 @@ func (m *MockTxRelayer) SendTransaction(
 
 func (m *MockTxRelayer) SendTransactionLocal(txn *ethgo.Transaction) (*ethgo.Receipt, error) {
 	args := m.Called(txn)
+
 	receipt, ok := args.Get(0).(*ethgo.Receipt)
 	if !ok {
 		panic("Expected *ethgo.Receipt but got a different type")
@@ -137,6 +144,7 @@ func (m *MockTxRelayer) SendTransactionLocal(txn *ethgo.Transaction) (*ethgo.Rec
 
 func (m *MockTxRelayer) Client() *jsonrpc.Client {
 	args := m.Called()
+
 	client, ok := args.Get(0).(*jsonrpc.Client)
 	if !ok {
 		panic("Expected *jsonrpc.Client but got a different type")
@@ -168,6 +176,7 @@ func (m *MockStateProvider) GetPriceOracleState(
 	validatorAccount *wallet.Account,
 ) (PriceOracleState, error) {
 	args := m.Called(header, validatorAccount)
+
 	state, ok := args.Get(0).(PriceOracleState)
 	if !ok {
 		panic("Expected PriceOracleState but got a different type")
@@ -183,6 +192,7 @@ type MockPriceFeed struct {
 
 func (m *MockPriceFeed) GetPrice(header *types.Header) (*big.Int, error) {
 	args := m.Called(header)
+
 	price, ok := args.Get(0).(*big.Int)
 	if !ok {
 		panic("Expected *big.Int but got a different type")

--- a/price-oracle/price_feed.go
+++ b/price-oracle/price_feed.go
@@ -80,6 +80,7 @@ func getCoingeckoPrice(apiKey string) (*big.Int, error) {
 	}
 
 	var priceData PriceDataCoinGecko
+
 	err = json.Unmarshal(body, &priceData)
 	if err != nil {
 		return nil, fmt.Errorf("failed to unmarshal response: %w", err)

--- a/price-oracle/price_oracle.go
+++ b/price-oracle/price_oracle.go
@@ -200,6 +200,7 @@ func (p *PriceOracle) shouldExecuteVote(header *types.Header) (bool, error) {
 
 	// then check if the contract is in a proper state to vote
 	dayNumber := calcDayNumber(header.Timestamp)
+
 	shouldVote, falseReason, err := state.shouldVote(dayNumber)
 	if err != nil {
 		return false, err

--- a/price-oracle/price_oracle.go
+++ b/price-oracle/price_oracle.go
@@ -299,9 +299,9 @@ func (p *PriceOracle) vote(price *big.Int) error {
 				return fmt.Errorf("failed to parse log: %w", err)
 			}
 
-			result.price = event["price"].(*big.Int).String()
-			result.validatorAddress = event["validator"].(ethgo.Address).String()
-			result.day = event["day"].(*big.Int).Uint64()
+			result.price = event["price"].(*big.Int).String()                     //nolint:forcetypeassert
+			result.validatorAddress = event["validator"].(ethgo.Address).String() //nolint:forcetypeassert
+			result.day = event["day"].(*big.Int).Uint64()                         //nolint:forcetypeassert
 
 			foundVoteLog = true
 		}
@@ -341,7 +341,7 @@ func isVotingTime(timestamp uint64) bool {
 
 // isBlockOlderThan checks if the block is older than the given number of minutes
 func isBlockOlderThan(header *types.Header, minutes int64) bool {
-	return time.Now().UTC().Unix()-int64(header.Timestamp) > minutes*60 //nolint:gosec
+	return time.Now().UTC().Unix()-int64(header.Timestamp) > minutes*60
 }
 
 func calcDayNumber(timestamp uint64) uint64 {

--- a/price-oracle/price_oracle_test.go
+++ b/price-oracle/price_oracle_test.go
@@ -484,17 +484,17 @@ func TestVote(t *testing.T) {
 			require.Equal(
 				t,
 				expectedPrice.String(),
-				event["price"].(*big.Int).String(),
+				event["price"].(*big.Int).String(), //nolint:forcetypeassert
 			)
 			require.Equal(
 				t,
 				account.Ecdsa.Address().String(),
-				event["validator"].(ethgo.Address).String(),
+				event["validator"].(ethgo.Address).String(), //nolint:forcetypeassert
 			)
 			require.Equal(
 				t,
 				big.NewInt(1),
-				event["day"].(*big.Int),
+				event["day"].(*big.Int), //nolint:forcetypeassert
 			)
 			foundVoteLog = true
 		}
@@ -647,17 +647,17 @@ func TestExecuteVote(t *testing.T) {
 			require.Equal(
 				t,
 				expectedPrice.String(),
-				event["price"].(*big.Int).String(),
+				event["price"].(*big.Int).String(), //nolint:forcetypeassert
 			)
 			require.Equal(
 				t,
 				account.Ecdsa.Address().String(),
-				event["validator"].(ethgo.Address).String(),
+				event["validator"].(ethgo.Address).String(), //nolint:forcetypeassert
 			)
 			require.Equal(
 				t,
 				big.NewInt(1),
-				event["day"].(*big.Int),
+				event["day"].(*big.Int), //nolint:forcetypeassert
 			)
 			foundVoteLog = true
 		}

--- a/price-oracle/price_oracle_test.go
+++ b/price-oracle/price_oracle_test.go
@@ -90,6 +90,7 @@ func TestIsValidator(t *testing.T) {
 			isValidator, err := priceOracle.isValidator(tt.block)
 
 			require.Equal(t, tt.expectedIsValidator, isValidator)
+
 			if tt.expectedError != nil {
 				require.EqualError(t, err, tt.expectedError.Error())
 			} else {
@@ -416,6 +417,7 @@ func TestShouldExecuteVote(t *testing.T) {
 
 			// Assert the results
 			require.Equal(t, tt.expectedResult, result)
+
 			if tt.expectedError != nil {
 				require.EqualError(t, err, tt.expectedError.Error())
 			} else {
@@ -496,6 +498,7 @@ func TestVote(t *testing.T) {
 				big.NewInt(1),
 				event["day"].(*big.Int), //nolint:forcetypeassert
 			)
+
 			foundVoteLog = true
 		}
 	}
@@ -659,6 +662,7 @@ func TestExecuteVote(t *testing.T) {
 				big.NewInt(1),
 				event["day"].(*big.Int), //nolint:forcetypeassert
 			)
+
 			foundVoteLog = true
 		}
 	}

--- a/secrets/encryptedlocal/encryptedlocal.go
+++ b/secrets/encryptedlocal/encryptedlocal.go
@@ -113,6 +113,7 @@ func baseOnSetHandler(
 		esm.logger.Error(
 			"The secret value you entered does not match the original value. Please try again.",
 		)
+
 		return nil, errors.New("secret value mismatch")
 	} else {
 		esm.logger.Info("The secret value you entered matches the original value. Continuing.")

--- a/secrets/encryptedlocal/encryptedlocal.go
+++ b/secrets/encryptedlocal/encryptedlocal.go
@@ -51,6 +51,7 @@ func SecretsManagerFactory(
 
 func (esm *EncryptedLocalSecretsManager) SetSecret(name string, value []byte) error {
 	esm.logger.Info("Configuring secret", "name", name)
+
 	onSetHandler, ok := onSetHandlers[name]
 	if ok {
 		res, err := onSetHandler(esm, name, value)
@@ -101,6 +102,7 @@ func baseOnSetHandler(
 		name,
 		string(value),
 	)
+
 	confirmValue, err := esm.prompt.DefaultPrompt(
 		`Please re-type the secret key value (present above, after the "=") to confirm that you have backed it up in a safe location.`,
 		"",
@@ -147,6 +149,7 @@ func baseOnGetHandler(
 ) ([]byte, error) {
 	if esm.pwd == nil || len(esm.pwd) == 0 {
 		var err error
+
 		esm.pwd, err = esm.prompt.InputPassword(false)
 		if err != nil {
 			return nil, err

--- a/secrets/encryptedlocal/encryption.go
+++ b/secrets/encryptedlocal/encryption.go
@@ -54,6 +54,7 @@ func (ch *encryption) Encrypt(data []byte, pwd []byte) ([]byte, error) {
 
 func (ch *encryption) Decrypt(data []byte, pwd []byte) ([]byte, error) {
 	salt, data := data[len(data)-32:], data[:len(data)-32]
+
 	key, _, err := DeriveKey(pwd, salt)
 	if err != nil {
 		return nil, err
@@ -75,6 +76,7 @@ func (ch *encryption) Decrypt(data []byte, pwd []byte) ([]byte, error) {
 	}
 
 	nonce, ciphertext := data[:nonceSize], data[nonceSize:]
+
 	plaintext, err := gcm.Open(nil, nonce, ciphertext, nil)
 	if err != nil {
 		return nil, err

--- a/secrets/encryptedlocal/prompt.go
+++ b/secrets/encryptedlocal/prompt.go
@@ -51,6 +51,7 @@ func (p *Prompt) GenerateMnemonic(generator MnemonicGenerator) (string, error) {
 	fmt.Println("\nWe must generate a mnemonic which will represent your node account.")
 	fmt.Println("\nKeep it safe and do not share it with anyone.")
 	fmt.Println("\nYou will need this mnemonic to recover your node account if you lose it.")
+
 	start, err := p.DefaultPrompt("Do you want to start the process? [y/n]", "y")
 	if err != nil {
 		return "", err
@@ -67,6 +68,7 @@ func (p *Prompt) GenerateMnemonic(generator MnemonicGenerator) (string, error) {
 	}
 
 	fmt.Println("\nHere is your mnemonic. Please copy it and store it in a safe place.")
+
 	repeatMnemonic, err := p.DefaultPrompt(
 		"Please re-type the mnemonic to confirm that you have backed it up in a safe location.",
 		"",
@@ -77,10 +79,6 @@ func (p *Prompt) GenerateMnemonic(generator MnemonicGenerator) (string, error) {
 
 	if repeatMnemonic != mnemonic {
 		return "", errors.New("mnemonic mismatch")
-	}
-
-	if err != nil {
-		return "", err
 	}
 
 	return mnemonic, nil
@@ -95,6 +93,7 @@ func (p *Prompt) InputPassword(verify bool) ([]byte, error) {
 		}
 
 		fmt.Print("Enter password: ")
+
 		bytePassword, err := p.readPassword()
 		if err != nil {
 			return nil, err
@@ -112,6 +111,7 @@ func (p *Prompt) InputPassword(verify bool) ([]byte, error) {
 func (p *Prompt) ConfirmPassword(password []byte) (pass []byte, err error) {
 	return p.promptUntil(func() ([]byte, error) {
 		fmt.Print("\nConfirm password: ")
+
 		rePassword, err := p.readPassword()
 		if err != nil {
 			return nil, fmt.Errorf("error reading password: %w", err)
@@ -131,16 +131,18 @@ func (p *Prompt) readPassword() ([]byte, error) {
 
 // DefaultPrompt prompts the user for any text and performs no validation. If nothing is entered it returns the default.
 func (p *Prompt) DefaultPrompt(promptText, defaultValue string) (string, error) {
-	var response string
 	if defaultValue != "" {
 		fmt.Printf("%s %s:\n", promptText, fmt.Sprintf("(default: %s)", defaultValue))
 	} else {
 		fmt.Printf("%s:\n", promptText)
 	}
 
+	var response string
+
 	scanner := bufio.NewScanner(os.Stdin)
 	if ok := scanner.Scan(); ok {
 		item := scanner.Text()
+
 		response = strings.TrimRight(item, "\r\n")
 		if response == "" {
 			return defaultValue, nil
@@ -180,6 +182,7 @@ func (p *Prompt) promptUntil(action func() (res []byte, err error)) (res []byte,
 		res, err := action()
 		if err != nil {
 			fmt.Printf("\n %s \n", err)
+
 			agree, err := p.tryAgain()
 			if err != nil {
 				return nil, err

--- a/secrets/encryptedlocal/prompt.go
+++ b/secrets/encryptedlocal/prompt.go
@@ -15,10 +15,11 @@ import (
 
 var (
 	ErrInvalidPassword = errors.New(
-		"Password must contain at least one number, one uppercase letter, one special character, and be at least 8 characters long",
+		"password must contain at least one number, one uppercase letter, one special character," +
+			" and be at least 8 characters long",
 	)
-	ErrPasswordMismatch    = errors.New("Passwords do not match")
-	ErrTerminatedOperation = errors.New("Operation terminated")
+	ErrPasswordMismatch    = errors.New("passwords do not match")
+	ErrTerminatedOperation = errors.New("operation terminated")
 )
 
 type Prompt struct {
@@ -61,6 +62,9 @@ func (p *Prompt) GenerateMnemonic(generator MnemonicGenerator) (string, error) {
 	}
 
 	mnemonic, err := generator.GenerateMnemonic()
+	if err != nil {
+		return "", err
+	}
 
 	fmt.Println("\nHere is your mnemonic. Please copy it and store it in a safe place.")
 	repeatMnemonic, err := p.DefaultPrompt(
@@ -141,6 +145,7 @@ func (p *Prompt) DefaultPrompt(promptText, defaultValue string) (string, error) 
 		if response == "" {
 			return defaultValue, nil
 		}
+
 		return response, nil
 	}
 
@@ -205,6 +210,7 @@ func (p *Prompt) tryAgain() (agree bool, err error) {
 		return false, nil
 	default:
 		fmt.Println("Invalid input")
+
 		return p.tryAgain()
 	}
 }

--- a/secrets/secrets.go
+++ b/secrets/secrets.go
@@ -36,7 +36,7 @@ const (
 	ValidatorBLSSignature = "validator-bls-signature"
 
 	// CoinGeckoAPIKey is the API key for the coingecko endpoints
-	CoinGeckoAPIKey = "coingecko-api-key"
+	CoinGeckoAPIKey = "coingecko-api-key" //nolint:gosec
 )
 
 // Define constant file names for the local StorageManager

--- a/server/server.go
+++ b/server/server.go
@@ -196,6 +196,7 @@ func NewServer(config *Config) (*Server, error) {
 		if err != nil {
 			return nil, err
 		}
+
 		m.network = network
 	}
 
@@ -372,6 +373,7 @@ func NewServer(config *Config) (*Server, error) {
 		if err := m.setupConsensus(); err != nil {
 			return nil, err
 		}
+
 		m.blockchain.SetConsensus(m.consensus)
 	}
 

--- a/state/executor.go
+++ b/state/executor.go
@@ -611,7 +611,7 @@ func (t *Transition) apply(msg *types.Transaction) (*runtime.ExecutionResult, er
 		result = t.Call2(msg.From, *msg.To, msg.Input, value, gasLeft)
 	}
 
-	// H: In case call is not successful and the amount is not transfered,
+	// H: In case call is not successful and the amount is not transferred,
 	// remove it from the system address
 	if areCoinsMinted && result != nil && result.Failed() {
 		err := t.state.SubBalance(msg.From, msg.Value)

--- a/state/executor.go
+++ b/state/executor.go
@@ -567,8 +567,10 @@ func (t *Transition) apply(msg *types.Transaction) (*runtime.ExecutionResult, er
 	// System transactions are verified at a higher level in fsm
 	// The above ensures fresh balance can be added only when consensus rules are met
 	areCoinsMinted := false
+
 	if msg.From == contracts.SystemCaller && msg.Value.Cmp(big.NewInt(0)) > 0 {
 		t.state.AddBalance(msg.From, msg.Value)
+
 		areCoinsMinted = true
 	}
 
@@ -608,6 +610,7 @@ func (t *Transition) apply(msg *types.Transaction) (*runtime.ExecutionResult, er
 		if err := t.state.IncrNonce(msg.From); err != nil {
 			return nil, err
 		}
+
 		result = t.Call2(msg.From, *msg.To, msg.Input, value, gasLeft)
 	}
 

--- a/state/immutable-trie/copy_trie.go
+++ b/state/immutable-trie/copy_trie.go
@@ -195,6 +195,7 @@ func hashChecker(node Node, h *hasher, a *fastrlp.Arena, d int, storage Storage)
 				if err != nil {
 					return nil, err
 				}
+
 				val.Set(v)
 			}
 		}
@@ -207,6 +208,7 @@ func hashChecker(node Node, h *hasher, a *fastrlp.Arena, d int, storage Storage)
 			if err != nil {
 				return nil, err
 			}
+
 			val.Set(v)
 		}
 

--- a/state/immutable-trie/copy_trie.go
+++ b/state/immutable-trie/copy_trie.go
@@ -57,7 +57,7 @@ func copyTrieHash(nodeHash []byte, storage Storage, batchWriter Batch, agg []byt
 		return err
 	}
 
-	//copy whole bytes of nodes
+	// copy whole bytes of nodes
 	batchWriter.Put(nodeHash, data)
 
 	return copyTrieNode(node, storage, batchWriter, agg, isStorage)
@@ -84,7 +84,7 @@ func copyTrieNode(node Node, storage Storage, batchWriter Batch, agg []byte, isS
 		}
 
 	case *ValueNode:
-		//if node represens stored value, then we need to copy it
+		// if node represens stored value, then we need to copy it
 		if n.hash {
 			return copyTrieHash(n.buf, storage, batchWriter, agg, isStorage)
 		}

--- a/state/immutable-trie/copy_trie_test.go
+++ b/state/immutable-trie/copy_trie_test.go
@@ -13,16 +13,19 @@ func TestCompareModelOfTrieCopy(t *testing.T) {
 	rapid.Check(t, func(tt *rapid.T) {
 		ldbStorageOld := ldbstorage.NewMemStorage()
 		ldbStorageNew := ldbstorage.NewMemStorage()
+
 		ldb, err := leveldb.Open(ldbStorageOld, nil)
 		if err != nil {
 			t.Fatal(err)
 		}
+
 		defer ldb.Close()
 
 		ldbNew, err := leveldb.Open(ldbStorageNew, nil)
 		if err != nil {
 			t.Fatal(err)
 		}
+
 		defer ldbNew.Close()
 
 		kv := NewKV(ldb)
@@ -39,11 +42,14 @@ func TestCompareModelOfTrieCopy(t *testing.T) {
 		}
 
 		tx.Commit()
+
 		stateRoot := trie.Hash()
+
 		result, err := HashChecker(stateRoot.Bytes(), kv)
 		if err != nil {
 			t.Fatal(err)
 		}
+
 		if stateRoot != result {
 			t.Fatal("Hashes are not equal", stateRoot, result)
 		}
@@ -57,6 +63,7 @@ func TestCompareModelOfTrieCopy(t *testing.T) {
 		if err != nil {
 			t.Error(err)
 		}
+
 		if stateRoot != result {
 			t.Error("Hashes are not equal", stateRoot, result)
 		}

--- a/state/immutable-trie/hasher.go
+++ b/state/immutable-trie/hasher.go
@@ -117,6 +117,7 @@ func (t *Txn) Hash() ([]byte, error) {
 		}
 	} else {
 		tmp := val.MarshalTo(nil)
+
 		h.hash.Reset()
 		h.hash.Write(tmp)
 

--- a/state/immutable-trie/storage.go
+++ b/state/immutable-trie/storage.go
@@ -249,12 +249,15 @@ func decodeNode(v *fastrlp.Value, s Storage) (Node, error) {
 	} else if ll == 17 {
 		// full node
 		nc := &FullNode{}
+
 		for i := 0; i < 16; i++ {
 			if v.Get(i).Type() == fastrlp.TypeBytes && len(v.Get(i).Raw()) == 0 {
 				// empty
 				continue
 			}
+
 			nc.children[i], err = decodeNode(v.Get(i), s)
+
 			if err != nil {
 				return nil, err
 			}
@@ -263,6 +266,7 @@ func decodeNode(v *fastrlp.Value, s Storage) (Node, error) {
 		if v.Get(16).Type() != fastrlp.TypeBytes {
 			return nil, fmt.Errorf("full node value expected to be bytes")
 		}
+
 		if len(v.Get(16).Raw()) != 0 {
 			vv := &ValueNode{}
 			vv.buf = append(vv.buf[:0], v.Get(16).Raw()...)

--- a/state/immutable-trie/trie.go
+++ b/state/immutable-trie/trie.go
@@ -479,14 +479,14 @@ func (t *Txn) delete(node Node, search []byte) (Node, bool) {
 }
 
 func prefixLen(k1, k2 []byte) int {
-	max := len(k1)
-	if l := len(k2); l < max {
-		max = l
+	maximum := len(k1)
+	if l := len(k2); l < maximum {
+		maximum = l
 	}
 
 	var i int
 
-	for i = 0; i < max; i++ {
+	for i = 0; i < maximum; i++ {
 		if k1[i] != k2[i] {
 			break
 		}

--- a/state/runtime/addresslist/addresslist.go
+++ b/state/runtime/addresslist/addresslist.go
@@ -101,13 +101,14 @@ func (a *AddressList) runInputCall(caller types.Address, input []byte,
 
 	// write operation
 	var updateRole Role
-	if bytes.Equal(sig, SetAdminFunc.ID()) {
+	switch {
+	case bytes.Equal(sig, SetAdminFunc.ID()):
 		updateRole = AdminRole
-	} else if bytes.Equal(sig, SetEnabledFunc.ID()) {
+	case bytes.Equal(sig, SetEnabledFunc.ID()):
 		updateRole = EnabledRole
-	} else if bytes.Equal(sig, SetNoneFunc.ID()) {
+	case bytes.Equal(sig, SetNoneFunc.ID()):
 		updateRole = NoRole
-	} else {
+	default:
 		return nil, 0, errFunctionNotFound
 	}
 

--- a/state/runtime/addresslist/addresslist.go
+++ b/state/runtime/addresslist/addresslist.go
@@ -101,6 +101,7 @@ func (a *AddressList) runInputCall(caller types.Address, input []byte,
 
 	// write operation
 	var updateRole Role
+
 	switch {
 	case bytes.Equal(sig, SetAdminFunc.ID()):
 		updateRole = AdminRole

--- a/state/runtime/evm/bitmap.go
+++ b/state/runtime/evm/bitmap.go
@@ -39,6 +39,7 @@ func (b *bitmap) setCode(code []byte) {
 				// jumpdest
 				b.set(uint64(i))
 			}
+
 			i++
 		}
 	}

--- a/state/runtime/evm/bitmap_test.go
+++ b/state/runtime/evm/bitmap_test.go
@@ -13,6 +13,7 @@ func TestIsPush(t *testing.T) {
 			if !strings.HasPrefix(OpCode(i).String(), "PUSH") {
 				t.Fatal("err")
 			}
+
 			num++
 		}
 	}

--- a/state/runtime/evm/dispatch_table.go
+++ b/state/runtime/evm/dispatch_table.go
@@ -22,6 +22,7 @@ func registerRange(from, to OpCode, factory func(n int) instruction, gas uint64)
 	c := 1
 	for i := from; i <= to; i++ {
 		register(i, handler{factory(c), 0, gas})
+
 		c++
 	}
 }

--- a/state/runtime/evm/dispatch_table_test.go
+++ b/state/runtime/evm/dispatch_table_test.go
@@ -29,6 +29,7 @@ func TestPushOpcodes(t *testing.T) {
 		assert.Len(t, res, c)
 
 		assert.True(t, bytes.HasPrefix(code[1:], res))
+
 		c++
 	}
 }

--- a/state/runtime/evm/evm_test.go
+++ b/state/runtime/evm/evm_test.go
@@ -191,9 +191,11 @@ func TestRun(t *testing.T) {
 			contract := newMockContract(tt.value, tt.gas, tt.code)
 			host := &mockHost{}
 			config := tt.config
+
 			if config == nil {
 				config = &chain.ForksInTime{}
 			}
+
 			res := evm.Run(contract, host, config)
 			assert.Equal(t, tt.expected, res)
 		})
@@ -362,6 +364,7 @@ func TestRunWithTracer(t *testing.T) {
 			host := &mockHost{
 				tracer: tracer,
 			}
+
 			config := tt.config
 			if config == nil {
 				config = &chain.ForksInTime{}

--- a/state/runtime/evm/instructions.go
+++ b/state/runtime/evm/instructions.go
@@ -69,9 +69,11 @@ func opSDiv(c *state) {
 	} else {
 		neg := a.Sign() != b.Sign()
 		b.Div(a.Abs(a), b.Abs(b))
+
 		if neg {
 			b.Neg(b)
 		}
+
 		toU256(b)
 	}
 }
@@ -99,9 +101,11 @@ func opSMod(c *state) {
 	} else {
 		neg := a.Sign() < 0
 		b.Mod(a.Abs(a), b.Abs(b))
+
 		if neg {
 			b.Neg(b)
 		}
+
 		toU256(b)
 	}
 }
@@ -465,6 +469,7 @@ func opSload(c *state) {
 	loc := c.top()
 
 	var gas uint64
+
 	switch {
 	case c.config.Istanbul:
 		// eip-1884
@@ -578,6 +583,7 @@ func opBalance(c *state) {
 	addr, _ := c.popAddr()
 
 	var gas uint64
+
 	switch {
 	case c.config.Istanbul:
 		// eip-1884
@@ -1095,6 +1101,7 @@ func opCreate(op OpCode) instruction {
 		result := c.host.Callx(contract, c.host)
 
 		v := c.push1()
+
 		switch {
 		case op == CREATE && c.config.Homestead && errors.Is(result.Err, runtime.ErrCodeStoreOutOfGas):
 			v.Set(zero)
@@ -1264,6 +1271,7 @@ func (c *state) buildCallContract(op OpCode) (*runtime.Contract, uint64, uint64,
 
 			return nil, 0, 0, nil
 		}
+
 		gas = initialGas.Uint64()
 	}
 

--- a/state/runtime/evm/instructions_test.go
+++ b/state/runtime/evm/instructions_test.go
@@ -777,7 +777,9 @@ func Test_opCall(t *testing.T) {
 		test := tt
 		t.Run(test.name, func(t *testing.T) {
 			t.Parallel()
+
 			state, closeFn := getState()
+
 			defer closeFn()
 
 			state.gas = test.initState.gas

--- a/state/runtime/precompiled/base.go
+++ b/state/runtime/precompiled/base.go
@@ -4,7 +4,7 @@ import (
 	"crypto/sha256"
 	"math/big"
 
-	"golang.org/x/crypto/ripemd160" //nolint:staticcheck
+	"golang.org/x/crypto/ripemd160" //nolint:gosec // It should be fixed in the future.
 
 	"github.com/0xPolygon/polygon-edge/chain"
 	"github.com/0xPolygon/polygon-edge/crypto"
@@ -83,7 +83,7 @@ func (r *ripemd160h) gas(input []byte, config *chain.ForksInTime) uint64 {
 }
 
 func (r *ripemd160h) run(input []byte, _ types.Address, _ runtime.Host) ([]byte, error) {
-	ripemd := ripemd160.New()
+	ripemd := ripemd160.New() //nolint:gosec // It should be fixed in the future.
 	ripemd.Write(input)
 	res := ripemd.Sum(nil)
 

--- a/state/runtime/precompiled/blake2f_test.go
+++ b/state/runtime/precompiled/blake2f_test.go
@@ -17,6 +17,7 @@ func TestBlake2f(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
+
 		if !bytes.Equal(c.Expected, out) {
 			t.Fatal("bad")
 		}

--- a/state/runtime/precompiled/modexp.go
+++ b/state/runtime/precompiled/modexp.go
@@ -1,9 +1,8 @@
 package precompiled
 
 import (
-	"math/big"
-
 	"math"
+	"math/big"
 
 	"github.com/0xPolygon/polygon-edge/chain"
 	"github.com/0xPolygon/polygon-edge/state/runtime"
@@ -66,13 +65,14 @@ func subMul(x, a, b, c *big.Int) *big.Int {
 }
 
 func multComplexity(x *big.Int) *big.Int {
-	if x.Cmp(big64) <= 0 {
+	switch {
+	case x.Cmp(big64) <= 0:
 		// x ** x
 		x.Mul(x, x)
-	} else if x.Cmp(big1024) <= 0 {
+	case x.Cmp(big1024) <= 0:
 		// x ** 2 // 4 + 96 * x - 3072
 		x = subMul(x, big4, big96, big3072)
-	} else {
+	default:
 		// x ** 2 // 16 + 480 * x - 199680
 		x = subMul(x, big16, big480, big199680)
 	}

--- a/state/runtime/precompiled/precompiled.go
+++ b/state/runtime/precompiled/precompiled.go
@@ -115,8 +115,7 @@ func (p *Precompiled) CanRun(c *runtime.Contract, _ runtime.Host, config *chain.
 	}
 
 	// istanbul precompiles
-	switch c.CodeAddress {
-	case nine:
+	if c.CodeAddress == nine {
 		return config.Istanbul
 	}
 
@@ -141,7 +140,7 @@ func (p *Precompiled) Run(c *runtime.Contract, host runtime.Host, config *chain.
 		}
 	}
 
-	c.Gas = c.Gas - gasCost
+	c.Gas -= gasCost
 	returnValue, err := contract.run(c.Input, c.Caller, host)
 
 	result := &runtime.ExecutionResult{

--- a/state/transition_test.go
+++ b/state/transition_test.go
@@ -78,6 +78,7 @@ func TestSubGasLimitPrice(t *testing.T) {
 			err := transition.subGasLimitPrice(msg)
 
 			assert.Equal(t, tt.expectedErr, err)
+
 			if err == nil {
 				// should reduce cost for gas from balance
 				reducedAmount := new(big.Int).Mul(msg.GasPrice, big.NewInt(int64(msg.Gas)))
@@ -145,6 +146,7 @@ func TestTransfer(t *testing.T) {
 			err := transition.Transfer(tt.from, tt.to, amount)
 
 			assert.Equal(t, tt.expectedErr, err)
+
 			if err == nil {
 				// should move balance
 				oldBalanceOfFrom := big.NewInt(int64(tt.preState[tt.from].Balance))

--- a/state/txn.go
+++ b/state/txn.go
@@ -610,22 +610,21 @@ func (txn *Txn) Commit(deleteEmptyObjects bool) ([]*Object, error) {
 			DirtyCode: a.DirtyCode,
 			Code:      a.Code,
 		}
+
 		if a.Deleted {
 			obj.Deleted = true
-		} else {
-			if a.Txn != nil {
-				a.Txn.Root().Walk(func(k []byte, v interface{}) bool {
-					store := &StorageObject{Key: k}
-					if v == nil {
-						store.Deleted = true
-					} else {
-						store.Val = v.([]byte) //nolint:forcetypeassert
-					}
-					obj.Storage = append(obj.Storage, store)
+		} else if a.Txn != nil {
+			a.Txn.Root().Walk(func(k []byte, v interface{}) bool {
+				store := &StorageObject{Key: k}
+				if v == nil {
+					store.Deleted = true
+				} else {
+					store.Val = v.([]byte) //nolint:forcetypeassert
+				}
+				obj.Storage = append(obj.Storage, store)
 
-					return false
-				})
-			}
+				return false
+			})
 		}
 
 		objs = append(objs, obj)

--- a/state/txn.go
+++ b/state/txn.go
@@ -347,6 +347,7 @@ func (txn *Txn) IncrNonce(addr types.Address) error {
 
 			return
 		}
+
 		object.Account.Nonce++
 	})
 
@@ -430,6 +431,7 @@ func (txn *Txn) Suicide(addr types.Address) bool {
 			suicided = true
 			object.Suicide = true
 		}
+
 		if object != nil {
 			object.Account.Balance = new(big.Int)
 		}
@@ -555,6 +557,7 @@ func (txn *Txn) CleanDeleteObjects(deleteEmptyObjects bool) error {
 		if !ok {
 			return false
 		}
+
 		if a.Suicide || a.Empty() && deleteEmptyObjects {
 			remove = append(remove, k)
 		}
@@ -621,6 +624,7 @@ func (txn *Txn) Commit(deleteEmptyObjects bool) ([]*Object, error) {
 				} else {
 					store.Val = v.([]byte) //nolint:forcetypeassert
 				}
+
 				obj.Storage = append(obj.Storage, store)
 
 				return false

--- a/syncer/client.go
+++ b/syncer/client.go
@@ -162,7 +162,7 @@ func (m *syncPeerClient) GetConnectedPeerStatuses() []*NoForkPeer {
 			if err != nil {
 				m.logger.Warn("failed to get status from a peer, skip", "id", peerID, "err", err)
 
-				return //Skip appending nil status
+				return // Skip appending nil status
 			}
 
 			syncPeersLock.Lock()

--- a/tracker/event_tracker.go
+++ b/tracker/event_tracker.go
@@ -92,11 +92,13 @@ func (e *EventTracker) Start(ctx context.Context) error {
 	go common.RetryForever(ctx, time.Second, func(context.Context) error {
 		// Init
 		start := time.Now().UTC()
+
 		if err := blockTracker.Init(); err != nil {
 			e.logger.Error("failed to init blocktracker", "error", err)
 
 			return err
 		}
+
 		elapsed := time.Now().UTC().Sub(start)
 
 		// Start

--- a/tracker/event_tracker_store.go
+++ b/tracker/event_tracker_store.go
@@ -186,8 +186,8 @@ func (b *EventTrackerStore) GetEntry(hash string) (store.Entry, error) {
 }
 
 func (b *EventTrackerStore) getImplEntry(hash string) (*Entry, error) {
-	logsBucketName := append(dbLogs, []byte(hash)...)
-	nextToProcessBucketName := append(dbNextToProcess, []byte(hash)...)
+	logsBucketName := append(dbLogs, []byte(hash)...)                   //nolint:gocritic // It should be fixed in the future.
+	nextToProcessBucketName := append(dbNextToProcess, []byte(hash)...) //nolint:gocritic // It should be fixed in the future.
 
 	if err := b.conn.Update(func(tx *bolt.Tx) error {
 		if _, err := tx.CreateBucketIfNotExists(logsBucketName); err != nil {

--- a/txpool/account.go
+++ b/txpool/account.go
@@ -286,12 +286,9 @@ func (a *account) enqueue(tx *types.Transaction, replace bool) {
 
 	if !replace {
 		a.enqueued.push(tx)
-	} else {
-		// first -> try to replace in enqueued
-		if !replaceInQueue(a.enqueued.queue) {
-			// .. then try to replace in promoted
-			replaceInQueue(a.promoted.queue)
-		}
+	} else if !replaceInQueue(a.enqueued.queue) { // first -> try to replace in enqueued
+		// ... then try to replace in promoted
+		replaceInQueue(a.promoted.queue)
 	}
 }
 

--- a/txpool/event_subscription_test.go
+++ b/txpool/event_subscription_test.go
@@ -123,6 +123,7 @@ func TestEventSubscription_ProcessedEvents(t *testing.T) {
 
 			// Set the event listener
 			processed := int64(0)
+
 			go func() {
 				for range subscription.outputCh {
 					atomic.AddInt64(&processed, 1)
@@ -133,6 +134,7 @@ func TestEventSubscription_ProcessedEvents(t *testing.T) {
 			var wg sync.WaitGroup
 			for _, event := range testCase.events {
 				wg.Add(1)
+
 				go func(event *proto.TxPoolEvent) {
 					defer wg.Done()
 
@@ -141,8 +143,11 @@ func TestEventSubscription_ProcessedEvents(t *testing.T) {
 			}
 
 			wg.Wait()
+
 			eventWaitCtx, eventWaitFn := context.WithTimeout(context.Background(), 10*time.Second)
+
 			defer eventWaitFn()
+
 			if _, err := tests.RetryUntilTimeout(eventWaitCtx, func() (interface{}, bool) {
 				return nil, atomic.LoadInt64(&processed) < int64(testCase.expectedProcessed)
 			}); err != nil {

--- a/txpool/txpool.go
+++ b/txpool/txpool.go
@@ -665,13 +665,11 @@ func (p *TxPool) validateTx(tx *types.Transaction) error {
 
 			return ErrUnderpriced
 		}
-	} else {
+	} else if forks.London && tx.GasPrice.Cmp(new(big.Int).SetUint64(baseFee)) < 0 {
 		// Legacy approach to check if the given tx is not underpriced when london hardfork is enabled
-		if forks.London && tx.GasPrice.Cmp(new(big.Int).SetUint64(baseFee)) < 0 {
-			metrics.IncrCounter([]string{txPoolMetrics, "underpriced_tx"}, 1)
+		metrics.IncrCounter([]string{txPoolMetrics, "underpriced_tx"}, 1)
 
-			return ErrUnderpriced
-		}
+		return ErrUnderpriced
 	}
 
 	// Check if the given tx is not underpriced

--- a/txpool/txpool_test.go
+++ b/txpool/txpool_test.go
@@ -138,6 +138,7 @@ func TestAddTxErrors(t *testing.T) {
 
 	t.Run("ErrInvalidTxType", func(t *testing.T) {
 		t.Parallel()
+
 		pool := setupPool()
 
 		tx := newTx(defaultAddr, 0, 1)
@@ -157,6 +158,7 @@ func TestAddTxErrors(t *testing.T) {
 
 	t.Run("ErrTxTypeNotSupported London hardfork not enabled", func(t *testing.T) {
 		t.Parallel()
+
 		pool := setupPool()
 		pool.forks.RemoveFork(chain.London)
 
@@ -177,6 +179,7 @@ func TestAddTxErrors(t *testing.T) {
 
 	t.Run("ErrNegativeValue", func(t *testing.T) {
 		t.Parallel()
+
 		pool := setupPool()
 
 		tx := newTx(defaultAddr, 0, 1)
@@ -190,6 +193,7 @@ func TestAddTxErrors(t *testing.T) {
 
 	t.Run("ErrBlockLimitExceeded", func(t *testing.T) {
 		t.Parallel()
+
 		pool := setupPool()
 
 		tx := newTx(defaultAddr, 0, 1)
@@ -206,6 +210,7 @@ func TestAddTxErrors(t *testing.T) {
 
 	t.Run("ErrExtractSignature", func(t *testing.T) {
 		t.Parallel()
+
 		pool := setupPool()
 
 		tx := newTx(defaultAddr, 0, 1)
@@ -218,6 +223,7 @@ func TestAddTxErrors(t *testing.T) {
 
 	t.Run("ErrInvalidSender", func(t *testing.T) {
 		t.Parallel()
+
 		pool := setupPool()
 
 		tx := newTx(addr1, 0, 1)
@@ -234,6 +240,7 @@ func TestAddTxErrors(t *testing.T) {
 
 	t.Run("ErrUnderpriced", func(t *testing.T) {
 		t.Parallel()
+
 		pool := setupPool()
 		pool.priceLimit = 1000000
 
@@ -248,6 +255,7 @@ func TestAddTxErrors(t *testing.T) {
 
 	t.Run("ErrInvalidAccountState", func(t *testing.T) {
 		t.Parallel()
+
 		pool := setupPool()
 		pool.store = faultyMockStore{}
 
@@ -264,6 +272,7 @@ func TestAddTxErrors(t *testing.T) {
 
 	t.Run("ErrTxPoolOverflow", func(t *testing.T) {
 		t.Parallel()
+
 		pool := setupPool()
 
 		// fill the pool
@@ -280,6 +289,7 @@ func TestAddTxErrors(t *testing.T) {
 
 	t.Run("FillTxPoolToTheLimit", func(t *testing.T) {
 		t.Parallel()
+
 		pool := setupPool()
 
 		// fill the pool leaving only 1 slot
@@ -296,6 +306,7 @@ func TestAddTxErrors(t *testing.T) {
 
 	t.Run("ErrIntrinsicGas", func(t *testing.T) {
 		t.Parallel()
+
 		pool := setupPool()
 
 		tx := newTx(defaultAddr, 0, 1)
@@ -310,6 +321,7 @@ func TestAddTxErrors(t *testing.T) {
 
 	t.Run("ErrAlreadyKnown", func(t *testing.T) {
 		t.Parallel()
+
 		pool := setupPool()
 
 		tx := newTx(defaultAddr, 0, 1)
@@ -327,6 +339,7 @@ func TestAddTxErrors(t *testing.T) {
 
 	t.Run("ErrAlreadyKnown", func(t *testing.T) {
 		t.Parallel()
+
 		pool := setupPool()
 
 		tx := newTx(defaultAddr, 0, 1)
@@ -349,6 +362,7 @@ func TestAddTxErrors(t *testing.T) {
 
 	t.Run("ErrOversizedData", func(t *testing.T) {
 		t.Parallel()
+
 		pool := setupPool()
 
 		tx := newTx(defaultAddr, 0, 1)
@@ -369,6 +383,7 @@ func TestAddTxErrors(t *testing.T) {
 
 	t.Run("ErrNonceTooLow", func(t *testing.T) {
 		t.Parallel()
+
 		pool := setupPool()
 
 		// faultyMockStore.GetNonce() == 99999
@@ -384,6 +399,7 @@ func TestAddTxErrors(t *testing.T) {
 
 	t.Run("ErrInsufficientFunds", func(t *testing.T) {
 		t.Parallel()
+
 		pool := setupPool()
 
 		tx := newTx(defaultAddr, 0, 1)
@@ -530,6 +546,7 @@ func TestAddTxHighPressure(t *testing.T) {
 			pool.SetSigner(&mockSigner{})
 
 			pool.getOrCreateAccount(addr1)
+
 			pool.accounts.get(addr1).nextNonce = 5
 
 			//	mock high pressure
@@ -557,6 +574,7 @@ func TestAddTxHighPressure(t *testing.T) {
 			pool.SetSigner(&mockSigner{})
 
 			pool.getOrCreateAccount(addr1)
+
 			pool.accounts.get(addr1).nextNonce = 5
 
 			//	mock high pressure
@@ -2154,6 +2172,7 @@ func Test_TxPool_validateTx(t *testing.T) {
 
 	t.Run("tx input larger than the TxPoolMaxInitCodeSize", func(t *testing.T) {
 		t.Parallel()
+
 		pool := setupPool()
 		pool.forks = chain.AllForksEnabled.Copy()
 
@@ -2173,6 +2192,7 @@ func Test_TxPool_validateTx(t *testing.T) {
 
 	t.Run("tx input the same as TxPoolMaxInitCodeSize", func(t *testing.T) {
 		t.Parallel()
+
 		pool := setupPool()
 		pool.forks = chain.AllForksEnabled.Copy()
 
@@ -2297,6 +2317,7 @@ func Test_TxPool_validateTx(t *testing.T) {
 
 	t.Run("eip-1559 tx placed without eip-1559 fork enabled", func(t *testing.T) {
 		t.Parallel()
+
 		pool := setupPool()
 		pool.forks = chain.AllForksEnabled.Copy()
 		pool.forks.RemoveFork(chain.London)
@@ -2587,10 +2608,13 @@ func TestResetAccounts_Enqueued(t *testing.T) {
 		// setup prestate
 		totalTx := 0
 		expectedPromoted := uint64(0)
+
 		for addr, txs := range allTxs {
 			expectedPromoted += expected.accounts[addr].promoted
+
 			for _, tx := range txs {
 				totalTx++
+
 				assert.NoError(t, pool.addTx(local, tx))
 			}
 		}
@@ -2682,10 +2706,13 @@ func TestResetAccounts_Enqueued(t *testing.T) {
 		// setup prestate
 		expectedEnqueuedTx := 0
 		expectedPromotedTx := uint64(0)
+
 		for addr, txs := range allTxs {
 			expectedPromotedTx += expected.accounts[addr].promoted
+
 			for _, tx := range txs {
 				expectedEnqueuedTx++
+
 				assert.NoError(t, pool.addTx(local, tx))
 			}
 		}
@@ -2871,6 +2898,7 @@ func TestExecutablesOrder(t *testing.T) {
 			)
 
 			expectedPromotedTx := 0
+
 			for _, txs := range test.allTxs {
 				for _, tx := range txs {
 					expectedPromotedTx++
@@ -2889,6 +2917,7 @@ func TestExecutablesOrder(t *testing.T) {
 			pool.Prepare()
 
 			var successful []*types.Transaction
+
 			for {
 				tx := pool.Peek()
 				if tx == nil {
@@ -3068,6 +3097,7 @@ func TestRecovery(t *testing.T) {
 			// setup prestate
 			totalTx := 0
 			expectedEnqueued := uint64(0)
+
 			for addr, txs := range test.allTxs {
 				// preset nonce so promotions can happen
 				acc := pool.getOrCreateAccount(addr)
@@ -3078,6 +3108,7 @@ func TestRecovery(t *testing.T) {
 				// send txs
 				for _, sTx := range txs {
 					totalTx++
+
 					assert.NoError(t, pool.addTx(local, sTx.tx))
 				}
 			}
@@ -3090,6 +3121,7 @@ func TestRecovery(t *testing.T) {
 
 			func() {
 				pool.Prepare()
+
 				for {
 					tx := pool.Peek()
 					if tx == nil {
@@ -3288,9 +3320,11 @@ func TestGetTxs(t *testing.T) {
 
 			// send txs
 			expectedPromotedTx := 0
+
 			for _, txs := range test.allTxs {
 				nonce := uint64(0)
 				promotable := uint64(0)
+
 				for _, tx := range txs {
 					// send all txs
 					if tx.Nonce == nonce+promotable {
@@ -3385,6 +3419,7 @@ func TestSetSealing(t *testing.T) {
 
 			// Set initial value
 			pool.sealing.Store(false)
+
 			if test.initialValue {
 				pool.sealing.Store(true)
 			}

--- a/types/buildroot/buildroot_fast.go
+++ b/types/buildroot/buildroot_fast.go
@@ -7,14 +7,6 @@ import (
 	"github.com/0xPolygon/polygon-edge/helper/keccak"
 )
 
-func min(i, j int) int {
-	if i < j {
-		return i
-	}
-
-	return j
-}
-
 var fastHasherPool sync.Pool
 
 func acquireFastHasher() *FastHasher {

--- a/types/rlp_marshal.go
+++ b/types/rlp_marshal.go
@@ -38,6 +38,7 @@ func (b *Block) MarshalRLPWith(ar *fastrlp.Arena) *fastrlp.Value {
 		vv.Set(ar.NewNullArray())
 	} else {
 		v0 := ar.NewArray()
+
 		for _, tx := range b.Transactions {
 			if tx.Type != LegacyTx {
 				v0.Set(ar.NewCopyBytes([]byte{byte(tx.Type)}))
@@ -45,6 +46,7 @@ func (b *Block) MarshalRLPWith(ar *fastrlp.Arena) *fastrlp.Value {
 
 			v0.Set(tx.MarshalRLPWith(ar))
 		}
+
 		vv.Set(v0)
 	}
 
@@ -55,6 +57,7 @@ func (b *Block) MarshalRLPWith(ar *fastrlp.Arena) *fastrlp.Value {
 		for _, uncle := range b.Uncles {
 			v1.Set(uncle.MarshalRLPWith(ar))
 		}
+
 		vv.Set(v1)
 	}
 

--- a/types/rlp_marshal_storage.go
+++ b/types/rlp_marshal_storage.go
@@ -21,6 +21,7 @@ func (b *Body) marshalRLPWith(ar *fastrlp.Arena) *fastrlp.Value {
 		for _, tx := range b.Transactions {
 			v0.Set(tx.marshalStoreRLPWith(ar))
 		}
+
 		vv.Set(v0)
 	}
 
@@ -31,6 +32,7 @@ func (b *Body) marshalRLPWith(ar *fastrlp.Arena) *fastrlp.Value {
 		for _, uncle := range b.Uncles {
 			v1.Set(uncle.MarshalRLPWith(ar))
 		}
+
 		vv.Set(v1)
 	}
 

--- a/types/types.go
+++ b/types/types.go
@@ -49,21 +49,12 @@ type Hash [HashLength]byte
 
 type Address [AddressLength]byte
 
-func min(i, j int) int {
-	if i < j {
-		return i
-	}
-
-	return j
-}
-
 func BytesToHash(b []byte) Hash {
 	var h Hash
-
 	size := len(b)
-	min := min(size, HashLength)
+	minimum := min(size, HashLength)
 
-	copy(h[HashLength-min:], b[len(b)-min:])
+	copy(h[HashLength-minimum:], b[len(b)-minimum:])
 
 	return h
 }
@@ -129,9 +120,9 @@ func BytesToAddress(b []byte) Address {
 	var a Address
 
 	size := len(b)
-	min := min(size, AddressLength)
+	minimum := min(size, AddressLength)
 
-	copy(a[AddressLength-min:], b[len(b)-min:])
+	copy(a[AddressLength-minimum:], b[len(b)-minimum:])
 
 	return a
 }

--- a/types/types.go
+++ b/types/types.go
@@ -50,9 +50,9 @@ type Hash [HashLength]byte
 type Address [AddressLength]byte
 
 func BytesToHash(b []byte) Hash {
+	minimum := min(len(b), HashLength)
+
 	var h Hash
-	size := len(b)
-	minimum := min(size, HashLength)
 
 	copy(h[HashLength-minimum:], b[len(b)-minimum:])
 

--- a/validators/store/snapshot/types.go
+++ b/validators/store/snapshot/types.go
@@ -334,11 +334,12 @@ func (s *snapshotStore) findClosestSnapshotIndex(blockNum uint64) int {
 	for low <= high {
 		mid := (high + low) / 2
 
-		if blockNum < s.list[mid].Number {
+		switch {
+		case blockNum < s.list[mid].Number:
 			high = mid - 1
-		} else if blockNum > s.list[mid].Number {
+		case blockNum > s.list[mid].Number:
 			low = mid + 1
-		} else {
+		default:
 			return mid
 		}
 	}

--- a/validators/store/snapshot/types_test.go
+++ b/validators/store/snapshot/types_test.go
@@ -637,6 +637,7 @@ func TestSnapshotCopy(t *testing.T) {
 
 			// check addresses of Votes are different
 			assert.Equal(t, len(test.snapshot.Votes), len(copied.Votes))
+
 			for idx := range test.snapshot.Votes {
 				assert.NotSame(t, test.snapshot.Votes[idx], copied.Votes[idx])
 			}


### PR DESCRIPTION
# Description


Inside the configuration, the option `new-from-rev` is defined, this option will filter the results to only display reports from the diff between you branch and `origin/develop`.

```yml
issues:
  new-from-rev: origin/develop # report only new issues with reference to develop branch
```

https://golangci-lint.run/welcome/faq/#why---new-from-rev-or---new-from-patch-dont-seem-to-be-working-in-some-cases

I guess this was used because the project didn't want to fix all the reports in one row.

The diff is done with the branch `develop` (which was the default branch of https://github.com/0xPolygon/polygon-edge) but your default branch is not the same (`prod`).
So you will have differences inside your CI depending on which diff is evaluated. 

This PR will all the reports, so it removes the need for `new-from-rev`

Also, the project depends on min go1.21 and not go1.20.
And I run `go mod tidy`.

`actions/setup-go` must be done after `actions/setup-checkout` for cache optimizations.

I also updated the version of the actions.

This PR targets the branch of the PR https://github.com/Hydra-Chain/hydragon-node/pull/70, so this PR will be merged inside another PR and not inside `prod`.

# Changes include

- [ ] Bugfix (non-breaking change that solves an issue)
- [ ] Hotfix (change that solves an urgent issue, and requires immediate attention)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)

# Checklist

- [ ] I have assigned this PR to myself
- [ ] I have added at least 1 reviewer
- [ ] I have added the relevant labels
- [ ] I have updated the official documentation
- [ ] I have added sufficient documentation in code

## Testing

- [ ] I have tested this code with the official test suite
- [ ] I have tested this code manually
