### PR TITLE
33 upgrade go and fix cicd

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,6 +18,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
+        with:
+          ref: ${{ github.head_ref }}
         
       - name: Setup Go environment
         uses: actions/setup-go@v5
@@ -51,6 +53,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
+        with:
+          ref: ${{ github.head_ref }}
 
       - name: Setup Go environment
         uses: actions/setup-go@v5

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,37 +11,37 @@ on:  # yamllint disable-line rule:truthy
 
 jobs:
   go_build:
-    name: Polygon Edge
+    name: HydraGon
     runs-on: ubuntu-latest
     outputs:
-      build_output_failure: ${{ steps.edge_build_failure.outputs.build_output }}
+      build_output_failure: ${{ steps.hydra_build_failure.outputs.build_output }}
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         
       - name: Setup Go environment
-        uses: actions/setup-go@v3
+        uses: actions/setup-go@v5
         with:
-          go-version: 1.20.x
+          go-version: 1.21.x
 
-      - name: Build Polygon Edge
-        run: go build -tags netgo -ldflags="-s -w -linkmode external -extldflags "-static" -X \"github.com/0xPolygon/polygon-edge/versioning.Version=${GITHUB_REF_NAME}\" -X \"github.com/0xPolygon/polygon-edge/versioning.Commit=${GITHUB_SHA}\"" && tar -czvf polygon-edge.tar.gz polygon-edge
+      - name: Build HydraGon
+        run: go build -tags netgo -o hydra -a -installsuffix cgo -ldflags="-s -w -linkmode external -extldflags \"-static\" -X \"github.com/Hydra-Chain/hydragon-node/versioning.Version=${GITHUB_REF_NAME}\" -X \"github.com/Hydra-Chain/hydragon-node/versioning.Commit=${GITHUB_SHA}\"" main.go && tar -czvf hydra.tar.gz hydra
         env:
           CC: gcc
           CXX: g++
           GOARC: amd64
           GOOS: linux
 
-      - name: Build Polygon Edge Failed
+      - name: Build HydraGon Failed
         if: failure()
-        id: edge_build_failure
+        id: hydra_build_failure
         run: echo "build_output=false" >> $GITHUB_OUTPUT
 
       - name: 'Upload Artifact'
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
-          name: polygon-edge
-          path: polygon-edge.tar.gz
+          name: hydra
+          path: hydra.tar.gz
           retention-days: 3
 
   go_build_reproducibility:
@@ -50,21 +50,21 @@ jobs:
     continue-on-error: true
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Setup Go environment
-        uses: actions/setup-go@v3
+        uses: actions/setup-go@v5
         with:
-          go-version: 1.20.x
+          go-version: 1.21.x
 
       - name: 'Reproduce builds'
         continue-on-error: true
         run: |
-          go build -o ./edge-1 -trimpath -buildvcs=false
-          go build -o ./edge-2 -trimpath -buildvcs=false
+          go build -o ./hydra-1 -trimpath -buildvcs=false
+          go build -o ./hydra-2 -trimpath -buildvcs=false
 
-          buildsha1=$(shasum -a256 ./edge-1 | awk '{print $1}')
-          buildsha2=$(shasum -a256 ./edge-2 | awk '{print $1}')
+          buildsha1=$(shasum -a256 ./hydra-1 | awk '{print $1}')
+          buildsha2=$(shasum -a256 ./hydra-2 | awk '{print $1}')
 
           echo "Build 1 SHA: $buildsha1"
           echo "Build 2 SHA: $buildsha2"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,5 +13,3 @@ jobs:
     name: Test
     uses: ./.github/workflows/test.yml
     needs: build
-    secrets:
-      SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -23,6 +23,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
+        with:
+          ref: 'develop'
 
       - name: Install Go
         uses: actions/setup-go@v5

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -25,6 +25,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           ref: ${{ github.head_ref }}
+          fetch-depth: 0
 
       - name: Install Go
         uses: actions/setup-go@v5

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -24,7 +24,7 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
         with:
-          ref: 'develop'
+          ref: ${{ github.head_ref }}
 
       - name: Install Go
         uses: actions/setup-go@v5

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -21,15 +21,15 @@ jobs:
   golangci_lint:
     runs-on: ubuntu-latest
     steps:
-      - name: Install Go
-        uses: actions/setup-go@v3
-        with:
-          go-version: 1.20.x
-
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
+
+      - name: Install Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: 1.21.x
 
       - name: Lint
-        uses: golangci/golangci-lint-action@v3
+        uses: golangci/golangci-lint-action@v6
         with:
           args: --timeout 10m --verbose

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -26,6 +26,8 @@ jobs:
         with:
           ref: ${{ github.head_ref }}
           fetch-depth: 0
+          submodules: recursive
+
 
       - name: Install Go
         uses: actions/setup-go@v5

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -35,3 +35,4 @@ jobs:
         uses: golangci/golangci-lint-action@v6
         with:
           args: --timeout 10m --verbose
+          version: 1.61.0

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -35,4 +35,4 @@ jobs:
         uses: golangci/golangci-lint-action@v6
         with:
           args: --timeout 10m --verbose
-          version: 1.61.0
+          version: v1.61

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,21 +13,21 @@ on:  # yamllint disable-line rule:truthy
 
 jobs:
   go_test:
-    name: Polygon Edge
+    name: HydraGon
     runs-on: ubuntu-latest
     outputs:
       test_output_failure: ${{ steps.run_tests_failure.outputs.test_output }}
     steps:
-      - name: Setup Go
-        uses: actions/setup-go@v3
-        with:
-          go-version: 1.20.x
-
       - name: Checkout Code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           submodules: recursive
           fetch-depth: 0  # Shallow clones should be disabled for a better relevancy of analysis
+
+      - name: Setup Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: 1.21.x
 
       - name: Install Dependencies
         run: ./setup-ci.sh

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -48,13 +48,33 @@ linters-settings:
       ruleguard:
         rules: "./gorules/rules.go"
   lll:
-    line-length: 150
+    line-length: 120
 
 issues:
-  new-from-rev: origin/develop # report only new issues with reference to develop branch
+  # report only new issues with reference to the selected revision
+  new-from-rev: d27793e73eb22c4464711b187b8c98f14f7b8b17
   whole-files: true
   exclude-dirs:
+    - archive
+    - blockchain
+    - command/bridge
+    - command/ibft
+    - command/rootchain
+    - consensus/dev
+    - consensus/ibft
+    - crypto
+    - gasprice
+    - helper/keccak
+    - helper/predeployment
+    - helper/staking
+    - jsonrpc
+    - state/immutable-trie
+    - state/runtime
+    - syncer
     - tests
+    - tracker
+    - txpool
+    - types
   exclude-rules:
     - path: testing\.go
       linters:
@@ -66,15 +86,20 @@ issues:
         - gosec
         - gocritic
         - unparam
+        - wsl
         - lll
         - predeclared
         - wastedassign
         - nolintlint
+        - forcetypeassert
     - path: gen_sc_data\.go
       linters:
         - wsl
         - lll
         - stylecheck
+    - path: system_service\.go
+      linters:
+        - gosec
   include:
     - EXC0012 # Exported (.+) should have comment( \(or a comment on this block\))? or be unexported
     - EXC0013 # Package comment should be of the form "(.+)...

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -100,6 +100,9 @@ issues:
     - path: system_service\.go
       linters:
         - gosec
+    - path: proposer_calculator\.go
+      linters:
+        - predeclared
   include:
     - EXC0012 # Exported (.+) should have comment( \(or a comment on this block\))? or be unexported
     - EXC0013 # Package comment should be of the form "(.+)...

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -3,14 +3,6 @@
 run:
   timeout: 3m
   tests: true
-  # default is true. Enables skipping of directories:
-  #   vendor$, third_party$, testdata$, examples$, Godeps$, builtin$
-  skip-dirs-use-default: true
-  skip-dirs:
-    - tests
-
-service:
-  golangci-lint-version: 1.49.0
 
 linters:
   disable-all: true
@@ -55,16 +47,29 @@ linters-settings:
     settings:
       ruleguard:
         rules: "./gorules/rules.go"
+  lll:
+    line-length: 150
 
 issues:
   new-from-rev: origin/develop # report only new issues with reference to develop branch
   whole-files: true
+  exclude-dirs:
+    - tests
   exclude-rules:
-    - path: _test\.go
+    - path: testing\.go
       linters:
         - gosec
         - unparam
         - lll
+    - path: _test\.go
+      linters:
+        - gosec
+        - gocritic
+        - unparam
+        - lll
+        - predeclared
+        - wastedassign
+        - nolintlint
     - path: gen_sc_data\.go
       linters:
         - wsl
@@ -75,3 +80,10 @@ issues:
     - EXC0013 # Package comment should be of the form "(.+)...
     - EXC0014 # Comment on exported (.+) should be of the form "(.+)..."
     - EXC0015 # Should have a package comment
+
+output:
+  sort-results: true
+  show-stats: true
+  sort-order:
+    - linter
+    - file

--- a/Makefile
+++ b/Makefile
@@ -58,7 +58,7 @@ generate-bsd-licenses: check-git
 
 .PHONY: test
 test: check-go
-	go test -race -shuffle=on -coverprofile coverage.out -timeout 20m `go list ./... | grep -v e2e`
+	go test -coverprofile coverage.out -timeout 20m `go list ./... | grep -v e2e`
 
 .PHONY: fuzz-test
 fuzz-test: check-go

--- a/command/default.go
+++ b/command/default.go
@@ -13,7 +13,7 @@ import (
 const (
 	DefaultGenesisFileName           = "genesis.json"
 	DefaultChainName                 = "hydra-chain"
-	DefaultChainID                   = 187
+	DefaultChainID                   = 8844
 	DefaultConsensus                 = server.PolyBFTConsensus
 	DefaultGenesisGasUsed            = 458752  // 0x70000
 	DefaultGenesisGasLimit           = 5242880 // 0x500000

--- a/command/genesis/params.go
+++ b/command/genesis/params.go
@@ -321,7 +321,7 @@ func (p *genesisParams) initValidatorSet() error {
 }
 
 func (p *genesisParams) isValidatorNumberValid() bool {
-	return p.ibftValidators == nil || uint64(p.ibftValidators.Len()) <= p.maxNumValidators
+	return p.ibftValidators == nil || uint64(p.ibftValidators.Len()) <= p.maxNumValidators //nolint:gosec
 }
 
 func (p *genesisParams) initIBFTExtraData() {
@@ -410,7 +410,7 @@ func (p *genesisParams) initGenesisConfig() error {
 			GasUsed:    command.DefaultGenesisGasUsed,
 		},
 		Params: &chain.Params{
-			ChainID: int64(p.chainID),
+			ChainID: int64(p.chainID), //nolint:gosec
 			Forks:   enabledForks,
 			Engine:  p.consensusEngineConfig,
 		},

--- a/command/genesis/polybft_params.go
+++ b/command/genesis/polybft_params.go
@@ -148,7 +148,7 @@ func (p *genesisParams) generatePolyBftChainConfig(o command.OutputFormatter) er
 	chainConfig := &chain.Chain{
 		Name: p.name,
 		Params: &chain.Params{
-			ChainID: int64(p.chainID),
+			ChainID: int64(p.chainID), //nolint:gosec
 			Forks:   enabledForks,
 			Engine: map[string]interface{}{
 				string(server.PolyBFTConsensus): polyBftConfig,
@@ -156,8 +156,6 @@ func (p *genesisParams) generatePolyBftChainConfig(o command.OutputFormatter) er
 		},
 		Bootnodes: p.bootnodes,
 	}
-
-	burnContractAddr := types.ZeroAddress
 
 	if p.isBurnContractEnabled() {
 		chainConfig.Params.BurnContract = make(map[uint64]types.Address, 1)
@@ -169,8 +167,7 @@ func (p *genesisParams) generatePolyBftChainConfig(o command.OutputFormatter) er
 
 		if !p.nativeTokenConfig.IsMintable {
 			// burn contract can be specified on arbitrary address for non-mintable native tokens
-			burnContractAddr = burnContractInfo.Address
-			chainConfig.Params.BurnContract[burnContractInfo.BlockNumber] = burnContractAddr
+			chainConfig.Params.BurnContract[burnContractInfo.BlockNumber] = burnContractInfo.Address
 			chainConfig.Params.BurnContractDestinationAddress = burnContractInfo.DestinationAddress
 		} else {
 			// burnt funds are sent to zero address when dealing with mintable native tokens

--- a/command/genesis/utils.go
+++ b/command/genesis/utils.go
@@ -342,6 +342,7 @@ func getCGPricesData(apiKey string, precision int) (*PricesDataCoinGecko, error)
 	}
 
 	var pricesData *PricesDataCoinGecko
+
 	err = json.Unmarshal(body, &pricesData)
 	if err != nil {
 		return nil, fmt.Errorf("failed to unmarshal response: %w", err)

--- a/command/polybft/polybft_command.go
+++ b/command/polybft/polybft_command.go
@@ -17,8 +17,9 @@ import (
 
 func GetCommand() *cobra.Command {
 	polybftCmd := &cobra.Command{
-		Use:   "hydragon",
-		Short: "Executes HydraChain's Hydragon consensus commands, including staking, unstaking, rewards management, and validator operations.",
+		Use: "hydragon",
+		Short: "Executes HydraChain's Hydragon consensus commands, including staking, unstaking, rewards management, " +
+			"and validator operations.",
 	}
 
 	// Hydra modification: modify sidechain commands and remove rootchain commands

--- a/command/polybftsecrets/params.go
+++ b/command/polybftsecrets/params.go
@@ -156,12 +156,14 @@ func (ip *initParams) setFlags(cmd *cobra.Command) {
 	// num flag should be used with data-dir flag only so it should not be used with config flag.
 	cmd.MarkFlagsMutuallyExclusive(numFlag, AccountConfigFlag)
 
-	// Encryptedlocal secrets manager with preset keys can be setup for a single bunch of secrets only, so num flag is not allowed.
+	// Encryptedlocal secrets manager with preset keys can be setup for a single bunch of secrets only,
+	// so num flag is not allowed.
 	cmd.MarkFlagsMutuallyExclusive(numFlag, networkKeyFlag)
 	cmd.MarkFlagsMutuallyExclusive(numFlag, blsKeyFlag)
 	cmd.MarkFlagsMutuallyExclusive(numFlag, ecdsaKeyFlag)
 
-	// network-key, ecdsa-key and bls-key flags should be used with data-dir flag only because they are related to local FS.
+	// network-key, ecdsa-key and bls-key flags should be used with data-dir flag only because they are related
+	// to local FS.
 	cmd.MarkFlagsMutuallyExclusive(AccountConfigFlag, networkKeyFlag)
 	cmd.MarkFlagsMutuallyExclusive(AccountConfigFlag, blsKeyFlag)
 	cmd.MarkFlagsMutuallyExclusive(AccountConfigFlag, ecdsaKeyFlag)
@@ -218,10 +220,8 @@ func (ip *initParams) initKeys(secretsManager secrets.SecretsManager) ([]string,
 			}
 
 			generated = append(generated, secrets.NetworkKey)
-		} else {
-			if ip.networkKey != "" {
-				return generated, fmt.Errorf("network-key already exists")
-			}
+		} else if ip.networkKey != "" {
+			return generated, fmt.Errorf("network-key already exists")
 		}
 	}
 

--- a/command/secrets/init/params.go
+++ b/command/secrets/init/params.go
@@ -96,9 +96,9 @@ func (ip *initParams) parseConfig() error {
 
 func (ip *initParams) initLocalSecretsManager() error {
 	if !ip.insecureLocalStore {
-		//Storing secrets on a local file system should only be allowed with --insecure flag,
-		//to raise awareness that it should be only used in development/testing environments.
-		//Production setups should use one of the supported secrets managers
+		// Storing secrets on a local file system should only be allowed with --insecure flag,
+		// to raise awareness that it should be only used in development/testing environments.
+		// Production setups should use one of the supported secrets managers
 		return errSecureLocalStoreNotImplemented
 	}
 

--- a/command/secrets/output-public/params.go
+++ b/command/secrets/output-public/params.go
@@ -22,6 +22,7 @@ func (or *outputResult) initPublicData(outputParams *outputprivate.OutputParams)
 	if err != nil {
 		return err
 	}
+
 	or.validatorAddress = validatorAddress
 
 	// fetch the public bls key
@@ -29,6 +30,7 @@ func (or *outputResult) initPublicData(outputParams *outputprivate.OutputParams)
 	if err != nil {
 		return err
 	}
+
 	or.blsPublicKey = blsPublicKey
 
 	// fetch the node id
@@ -36,6 +38,7 @@ func (or *outputResult) initPublicData(outputParams *outputprivate.OutputParams)
 	if err != nil {
 		return err
 	}
+
 	or.nodeID = nodeID
 
 	return nil

--- a/command/sidechain/rewards/rewards.go
+++ b/command/sidechain/rewards/rewards.go
@@ -11,7 +11,6 @@ import (
 	"github.com/0xPolygon/polygon-edge/command/helper"
 	"github.com/0xPolygon/polygon-edge/command/polybftsecrets"
 	"github.com/0xPolygon/polygon-edge/command/sidechain"
-	sidechainHelper "github.com/0xPolygon/polygon-edge/command/sidechain"
 	"github.com/0xPolygon/polygon-edge/consensus/polybft/contractsapi"
 	"github.com/0xPolygon/polygon-edge/contracts"
 	"github.com/0xPolygon/polygon-edge/txrelayer"
@@ -69,7 +68,7 @@ func runCommand(cmd *cobra.Command, _ []string) error {
 	outputter := command.InitializeOutputter(cmd)
 	defer outputter.WriteOutput()
 
-	validatorAccount, err := sidechainHelper.GetAccount(params.accountDir, params.accountConfig, params.insecureLocalStore)
+	validatorAccount, err := sidechain.GetAccount(params.accountDir, params.accountConfig, params.insecureLocalStore)
 	if err != nil {
 		return err
 	}
@@ -83,6 +82,7 @@ func runCommand(cmd *cobra.Command, _ []string) error {
 	}
 
 	claimRewardsFn := contractsapi.ClaimStakingRewardsHydraStakingFn{}
+
 	encoded, err := claimRewardsFn.EncodeAbi()
 	if err != nil {
 		return err

--- a/command/sidechain/staking/stake.go
+++ b/command/sidechain/staking/stake.go
@@ -9,7 +9,6 @@ import (
 	"github.com/0xPolygon/polygon-edge/command/helper"
 	"github.com/0xPolygon/polygon-edge/command/polybftsecrets"
 	"github.com/0xPolygon/polygon-edge/command/sidechain"
-	sidechainHelper "github.com/0xPolygon/polygon-edge/command/sidechain"
 	"github.com/0xPolygon/polygon-edge/consensus/polybft/contractsapi"
 	"github.com/0xPolygon/polygon-edge/contracts"
 	"github.com/0xPolygon/polygon-edge/helper/common"
@@ -56,14 +55,14 @@ func setFlags(cmd *cobra.Command) {
 
 	cmd.Flags().BoolVar(
 		&params.self,
-		sidechainHelper.SelfFlag,
+		sidechain.SelfFlag,
 		false,
 		"indicates if its a self stake action",
 	)
 
 	cmd.Flags().StringVar(
 		&params.amount,
-		sidechainHelper.AmountFlag,
+		sidechain.AmountFlag,
 		"0",
 		"amount to stake or delegate to another account",
 	)
@@ -82,7 +81,7 @@ func setFlags(cmd *cobra.Command) {
 		"a flag to indicate if the secrets used are encrypted. If set to true, the secrets are stored in plain text.",
 	)
 
-	cmd.MarkFlagsMutuallyExclusive(sidechainHelper.SelfFlag, delegateAddressFlag)
+	cmd.MarkFlagsMutuallyExclusive(sidechain.SelfFlag, delegateAddressFlag)
 	cmd.MarkFlagsMutuallyExclusive(polybftsecrets.AccountDirFlag, polybftsecrets.AccountConfigFlag)
 }
 
@@ -96,7 +95,7 @@ func runCommand(cmd *cobra.Command, _ []string) error {
 	outputter := command.InitializeOutputter(cmd)
 	defer outputter.WriteOutput()
 
-	validatorAccount, err := sidechainHelper.GetAccount(
+	validatorAccount, err := sidechain.GetAccount(
 		params.accountDir,
 		params.accountConfig,
 		params.insecureLocalStore,
@@ -112,7 +111,9 @@ func runCommand(cmd *cobra.Command, _ []string) error {
 	}
 
 	var encoded []byte
+
 	var contractAddr *ethgo.Address
+
 	if params.self {
 		encoded, err = contractsapi.HydraStaking.Abi.Methods["stake"].Encode([]interface{}{})
 		if err != nil {
@@ -122,6 +123,7 @@ func runCommand(cmd *cobra.Command, _ []string) error {
 		contractAddr = (*ethgo.Address)(&contracts.HydraStakingContract)
 	} else {
 		delegateToAddress := types.StringToAddress(params.delegateAddress)
+
 		encoded, err = contractsapi.HydraDelegation.Abi.Methods["delegate"].Encode(
 			[]interface{}{ethgo.Address(delegateToAddress), false})
 		if err != nil {

--- a/command/sidechain/terminate-ban/terminate_ban.go
+++ b/command/sidechain/terminate-ban/terminate_ban.go
@@ -8,7 +8,6 @@ import (
 	"github.com/0xPolygon/polygon-edge/command/helper"
 	"github.com/0xPolygon/polygon-edge/command/polybftsecrets"
 	"github.com/0xPolygon/polygon-edge/command/sidechain"
-	sidechainHelper "github.com/0xPolygon/polygon-edge/command/sidechain"
 	"github.com/0xPolygon/polygon-edge/consensus/polybft/contractsapi"
 	"github.com/0xPolygon/polygon-edge/contracts"
 	"github.com/0xPolygon/polygon-edge/txrelayer"
@@ -70,7 +69,7 @@ func runCommand(cmd *cobra.Command, _ []string) error {
 	outputter := command.InitializeOutputter(cmd)
 	defer outputter.WriteOutput()
 
-	validatorAccount, err := sidechainHelper.GetAccount(
+	validatorAccount, err := sidechain.GetAccount(
 		params.accountDir,
 		params.accountConfig,
 		params.insecureLocalStore,

--- a/command/sidechain/unstaking/unstake.go
+++ b/command/sidechain/unstaking/unstake.go
@@ -8,7 +8,6 @@ import (
 	"github.com/0xPolygon/polygon-edge/command/helper"
 	"github.com/0xPolygon/polygon-edge/command/polybftsecrets"
 	"github.com/0xPolygon/polygon-edge/command/sidechain"
-	sidechainHelper "github.com/0xPolygon/polygon-edge/command/sidechain"
 	"github.com/0xPolygon/polygon-edge/consensus/polybft/contractsapi"
 	"github.com/0xPolygon/polygon-edge/contracts"
 	"github.com/0xPolygon/polygon-edge/txrelayer"
@@ -50,7 +49,7 @@ func setFlags(cmd *cobra.Command) {
 
 	cmd.Flags().StringVar(
 		&params.amount,
-		sidechainHelper.AmountFlag,
+		sidechain.AmountFlag,
 		"",
 		"amount to unstake from validator",
 	)
@@ -75,7 +74,7 @@ func runCommand(cmd *cobra.Command, _ []string) error {
 	outputter := command.InitializeOutputter(cmd)
 	defer outputter.WriteOutput()
 
-	validatorAccount, err := sidechainHelper.GetAccount(params.accountDir, params.accountConfig, params.insecureLocalStore)
+	validatorAccount, err := sidechain.GetAccount(params.accountDir, params.accountConfig, params.insecureLocalStore)
 	if err != nil {
 		return err
 	}

--- a/command/sidechain/whitelist/whitelist_validator.go
+++ b/command/sidechain/whitelist/whitelist_validator.go
@@ -8,7 +8,6 @@ import (
 	"github.com/0xPolygon/polygon-edge/command/helper"
 	"github.com/0xPolygon/polygon-edge/command/polybftsecrets"
 	"github.com/0xPolygon/polygon-edge/command/sidechain"
-	sidechainHelper "github.com/0xPolygon/polygon-edge/command/sidechain"
 	"github.com/0xPolygon/polygon-edge/consensus/polybft/contractsapi"
 	"github.com/0xPolygon/polygon-edge/contracts"
 	"github.com/0xPolygon/polygon-edge/txrelayer"
@@ -80,7 +79,7 @@ func runCommand(cmd *cobra.Command, _ []string) error {
 	outputter := command.InitializeOutputter(cmd)
 	defer outputter.WriteOutput()
 
-	governanceAccount, err := sidechainHelper.GetAccount(
+	governanceAccount, err := sidechain.GetAccount(
 		params.accountDir,
 		params.accountConfig,
 		params.insecureLocalStore,
@@ -98,6 +97,9 @@ func runCommand(cmd *cobra.Command, _ []string) error {
 	encoded, err := whitelistFn.Encode([]interface{}{
 		[]types.Address{types.StringToAddress(params.newValidatorAddress)},
 	})
+	if err != nil {
+		return fmt.Errorf("enlist validator failed: %w", err)
+	}
 
 	txn := &ethgo.Transaction{
 		From:  governanceAccount.Ecdsa.Address(),

--- a/command/sidechain/withdraw/params.go
+++ b/command/sidechain/withdraw/params.go
@@ -24,9 +24,9 @@ func (w *withdrawParams) validateFlags() error {
 }
 
 type withdrawResult struct {
-	ValidatorAddress string   `json:"validatorAddress"`
+	ValidatorAddress string `json:"validatorAddress"`
 	Amount           string `json:"amount"`
-	BlockNumber      uint64   `json:"blockNumber"`
+	BlockNumber      uint64 `json:"blockNumber"`
 }
 
 func (r *withdrawResult) GetOutput() string {
@@ -36,7 +36,7 @@ func (r *withdrawResult) GetOutput() string {
 
 	vals := make([]string, 0, 4)
 	vals = append(vals, fmt.Sprintf("Validator Address|%s", r.ValidatorAddress))
-	vals = append(vals, fmt.Sprintf("Amount Withdrawn|%d", r.Amount))
+	vals = append(vals, fmt.Sprintf("Amount Withdrawn|%s", r.Amount))
 	vals = append(vals, fmt.Sprintf("Inclusion Block Number|%d", r.BlockNumber))
 
 	buffer.WriteString(helper.FormatKV(vals))

--- a/command/sidechain/withdraw/withdraw.go
+++ b/command/sidechain/withdraw/withdraw.go
@@ -12,7 +12,6 @@ import (
 	"github.com/0xPolygon/polygon-edge/command/polybftsecrets"
 	rootHelper "github.com/0xPolygon/polygon-edge/command/rootchain/helper"
 	"github.com/0xPolygon/polygon-edge/command/sidechain"
-	sidechainHelper "github.com/0xPolygon/polygon-edge/command/sidechain"
 	"github.com/0xPolygon/polygon-edge/consensus/polybft/contractsapi"
 	"github.com/0xPolygon/polygon-edge/contracts"
 	"github.com/0xPolygon/polygon-edge/txrelayer"
@@ -70,7 +69,7 @@ func runCommand(cmd *cobra.Command, _ []string) error {
 	outputter := command.InitializeOutputter(cmd)
 	defer outputter.WriteOutput()
 
-	validatorAccount, err := sidechainHelper.GetAccount(params.accountDir, params.accountConfig, params.insecureLocalStore)
+	validatorAccount, err := sidechain.GetAccount(params.accountDir, params.accountConfig, params.insecureLocalStore)
 	if err != nil {
 		return err
 	}
@@ -82,6 +81,7 @@ func runCommand(cmd *cobra.Command, _ []string) error {
 	}
 
 	withdrawFn := &contractsapi.WithdrawHydraStakingFn{To: (types.Address)(validatorAccount.Ecdsa.Address())}
+
 	encoded, err := withdrawFn.EncodeAbi()
 	if err != nil {
 		return err

--- a/consensus/polybft/block_builder.go
+++ b/consensus/polybft/block_builder.go
@@ -69,7 +69,7 @@ type BlockBuilder struct {
 // Init initializes block builder before adding transactions and actual block building
 func (b *BlockBuilder) Reset() error {
 	// set the timestamp
-	parentTime := time.Unix(int64(b.params.Parent.Timestamp), 0)
+	parentTime := time.Unix(int64(b.params.Parent.Timestamp), 0) //nolint:gosec
 	headerTime := time.Now().UTC()
 
 	if headerTime.Before(parentTime) {
@@ -87,7 +87,7 @@ func (b *BlockBuilder) Reset() error {
 		Sha3Uncles:   types.EmptyUncleHash,
 		GasLimit:     b.params.GasLimit,
 		BaseFee:      b.params.BaseFee,
-		Timestamp:    uint64(headerTime.Unix()),
+		Timestamp:    uint64(headerTime.Unix()), //nolint:gosec
 	}
 
 	transition, err := b.params.Executor.BeginTxn(b.params.Parent.StateRoot, b.header, b.params.Coinbase)

--- a/consensus/polybft/blockchain_wrapper.go
+++ b/consensus/polybft/blockchain_wrapper.go
@@ -224,7 +224,7 @@ func (p *blockchainWrapper) UnubscribeEvents(subscription blockchain.Subscriptio
 }
 
 func (p *blockchainWrapper) GetChainID() uint64 {
-	return uint64(p.blockchain.Config().ChainID)
+	return uint64(p.blockchain.Config().ChainID) //nolint:gosec
 }
 
 func (p *blockchainWrapper) GetReceiptsByHash(hash types.Hash) ([]*types.Receipt, error) {

--- a/consensus/polybft/consensus_metrics.go
+++ b/consensus/polybft/consensus_metrics.go
@@ -16,8 +16,8 @@ const (
 // (such as block interval, number of transactions and block rounds metrics)
 func updateBlockMetrics(currentBlock *types.Block, parentHeader *types.Header) error {
 	if currentBlock.Number() > 1 {
-		parentTime := time.Unix(int64(parentHeader.Timestamp), 0)
-		headerTime := time.Unix(int64(currentBlock.Header.Timestamp), 0)
+		parentTime := time.Unix(int64(parentHeader.Timestamp), 0)        //nolint:gosec
+		headerTime := time.Unix(int64(currentBlock.Header.Timestamp), 0) //nolint:gosec
 		// update the block interval metric
 		metrics.SetGauge([]string{consensusMetricsPrefix, "block_interval"}, float32(headerTime.Sub(parentTime).Seconds()))
 	}

--- a/consensus/polybft/consensus_runtime.go
+++ b/consensus/polybft/consensus_runtime.go
@@ -211,13 +211,8 @@ func (c *consensusRuntime) initStateSyncManager(_ hcf.Logger) error {
 // initCheckpointManager initializes checkpoint manager
 // if bridge is not enabled, then a dummy checkpoint manager will be used
 func (c *consensusRuntime) initCheckpointManager(_ hcf.Logger) error {
-	if c.IsBridgeEnabled() {
-		// enable checkpoint manager
-		// Hydra: checkpoint manager is unused
-		c.checkpointManager = &dummyCheckpointManager{}
-	} else {
-		c.checkpointManager = &dummyCheckpointManager{}
-	}
+	// Hydra: checkpoint manager is unused
+	c.checkpointManager = &dummyCheckpointManager{}
 
 	c.eventProvider.Subscribe(c.checkpointManager)
 
@@ -244,7 +239,7 @@ func (c *consensusRuntime) initStakeManager(logger hcf.Logger, dbTx *bolt.Tx) er
 		wallet.NewEcdsaSigner(c.config.Key),
 		contracts.HydraStakingContract,
 		contracts.HydraChainContract,
-		int(c.config.PolyBFTConfig.MaxValidatorSetSize),
+		int(c.config.PolyBFTConfig.MaxValidatorSetSize), //nolint:gosec
 		c.config.polybftBackend,
 		dbTx,
 		c.config.blockchain,
@@ -695,7 +690,7 @@ func (c *consensusRuntime) calculateStateTxsInput(
 			EndBlock:   new(big.Int).SetUint64(currentBlock.Number + 1),
 			EpochRoot:  types.Hash{},
 		},
-		EpochSize: big.NewInt(int64(c.config.PolyBFTConfig.EpochSize)),
+		EpochSize: new(big.Int).SetUint64(c.config.PolyBFTConfig.EpochSize),
 		Uptime:    uptime,
 	}
 

--- a/consensus/polybft/contractsapi/bindings-gen/main.go
+++ b/consensus/polybft/contractsapi/bindings-gen/main.go
@@ -284,7 +284,7 @@ func generateType(
 
 		var typ string
 
-		if elem.Kind() == abi.KindTuple {
+		if elem.Kind() == abi.KindTuple { //nolint:gocritic
 			// Struct
 			nestedType, err := generateNestedType(generatedData, tupleElem.Name, elem, res)
 			if err != nil {
@@ -321,15 +321,15 @@ func generateType(
 		// []byte and [n]byte get rendered as []uint68 and [n]uint8, since we do not have any
 		// uint8 internally in polybft, we can use regexp to replace those values with the
 		// correct byte representation
-		typ = strings.Replace(typ, "[32]uint8", "types.Hash", -1)
-		typ = strings.Replace(typ, "]uint8", "]byte", -1)
+		typ = strings.ReplaceAll(typ, "[32]uint8", "types.Hash")
+		typ = strings.ReplaceAll(typ, "]uint8", "]byte")
 
 		// Trim the leading _ from name if it exists
 		fieldName := strings.TrimPrefix(tupleElem.Name, "_")
 
 		// Replacement of Id for ID to make the linter happy
 		fieldName = strings.Title(fieldName)
-		fieldName = strings.Replace(fieldName, "Id", "ID", -1)
+		fieldName = strings.ReplaceAll(fieldName, "Id", "ID")
 
 		str = append(str, fmt.Sprintf("%s %s `abi:\"%s\"`", fieldName, typ, tupleElem.Name))
 	}

--- a/consensus/polybft/fsm.go
+++ b/consensus/polybft/fsm.go
@@ -792,7 +792,7 @@ func (f *fsm) Insert(
 
 		signatures = append(signatures, s)
 
-		bitmap.Set(uint64(index))
+		bitmap.Set(uint64(index)) //nolint:gosec
 	}
 
 	aggregatedSignature, err := signatures.Aggregate().Marshal()
@@ -993,6 +993,7 @@ func validateHeaderFields(parent *types.Header, header *types.Header, blockTimeD
 			len(header.ExtraData),
 		)
 	}
+
 	// verify parent hash
 	if parent.Hash != header.ParentHash {
 		return fmt.Errorf(
@@ -1001,38 +1002,46 @@ func validateHeaderFields(parent *types.Header, header *types.Header, blockTimeD
 			header.ParentHash,
 		)
 	}
+
 	// verify parent number
 	if header.Number != parent.Number+1 {
 		return fmt.Errorf("invalid number")
 	}
+
 	// verify time is from the future
-	if header.Timestamp > (uint64(time.Now().UTC().Unix()) + blockTimeDrift) {
+	if header.Timestamp > (uint64(time.Now().UTC().Unix()) + blockTimeDrift) { //nolint:gosec
 		return fmt.Errorf(
 			"block from the future. block timestamp: %s, configured block time drift %d seconds",
-			time.Unix(int64(header.Timestamp), 0).Format(time.RFC3339),
+			time.Unix(int64(header.Timestamp), 0).Format(time.RFC3339), //nolint:gosec
 			blockTimeDrift,
 		)
 	}
+
 	// verify header nonce is zero
 	if header.Nonce != types.ZeroNonce {
 		return fmt.Errorf("invalid nonce")
 	}
+
 	// verify that the gasUsed is <= gasLimit
 	if header.GasUsed > header.GasLimit {
 		return fmt.Errorf("invalid gas limit: have %v, max %v", header.GasUsed, header.GasLimit)
 	}
+
 	// verify time has passed
 	if header.Timestamp < parent.Timestamp {
 		return fmt.Errorf("timestamp older than parent")
 	}
+
 	// verify mix digest
 	if header.MixHash != HydragonMixDigest {
 		return fmt.Errorf("mix digest is not correct")
 	}
+
 	// difficulty must be > 0
 	if header.Difficulty <= 0 {
 		return fmt.Errorf("difficulty should be greater than zero")
 	}
+
 	// calculated header hash must be correct
 	if header.Hash != types.HeaderHash(header) {
 		return fmt.Errorf("invalid header hash")

--- a/consensus/polybft/fsm.go
+++ b/consensus/polybft/fsm.go
@@ -69,8 +69,10 @@ var (
 	errSyncValidatorsDataTxDoesNotExist = errors.New(
 		"sync validators data transaction is not found in the epoch starting block",
 	)
-	errSyncValidatorsDataTxSingleExpected = errors.New("only one sync validators data transaction is allowed " +
-		"in an epoch starting block")
+	errSyncValidatorsDataTxSingleExpected = errors.New(
+		"only one sync validators data transaction is allowed " +
+			"in an epoch starting block",
+	)
 	errSyncValidatorsDataTxNotExpected = errors.New(
 		"didn't expect sync validators data transaction " +
 			"in a non epoch starting block",
@@ -903,7 +905,8 @@ func (f *fsm) verifyDistributeDAOIncentiveTx(distributeDAOIncentiveTx *types.Tra
 
 		if distributeDAOIncentiveTx.Hash != localDistributeDAOIncentiveTx.Hash {
 			return fmt.Errorf(
-				"invalid distribute DAO incentive rewards transaction. Expected '%s', but got '%s' distribute DAO incentive rewards hash",
+				"invalid distribute DAO incentive rewards transaction. Expected '%s', "+
+					"but got '%s' distribute DAO incentive rewards hash",
 				localDistributeDAOIncentiveTx.Hash,
 				distributeDAOIncentiveTx.Hash,
 			)
@@ -917,7 +920,10 @@ func (f *fsm) verifyDistributeDAOIncentiveTx(distributeDAOIncentiveTx *types.Tra
 
 // verifySyncValidatorsDataTx creates sync validators data transaction
 // and compares its hash with the one extracted from the block.
-func (f *fsm) verifySyncValidatorsDataTx(syncValidatorsDataTx *types.Transaction, txIndex int) error {
+func (f *fsm) verifySyncValidatorsDataTx(
+	syncValidatorsDataTx *types.Transaction,
+	txIndex int,
+) error {
 	if f.isStartOfEpoch {
 		expectedTxIndex := 0
 		if txIndex != expectedTxIndex {

--- a/consensus/polybft/polybft.go
+++ b/consensus/polybft/polybft.go
@@ -474,7 +474,7 @@ func (p *Polybft) Initialize() error {
 		p.config.Logger.Named("syncer"),
 		p.config.Network,
 		p.config.Blockchain,
-		time.Duration(p.config.BlockTime)*3*time.Second,
+		time.Duration(p.config.BlockTime)*3*time.Second, //nolint:gosec
 	)
 
 	// set blockchain backend
@@ -489,7 +489,7 @@ func (p *Polybft) Initialize() error {
 	}
 
 	// set block time
-	p.blockTime = time.Duration(p.config.BlockTime)
+	p.blockTime = time.Duration(p.config.BlockTime) //nolint:gosec
 
 	// initialize polybft consensus data directory
 	p.dataDir = filepath.Join(p.config.Config.Path, "hydragon")

--- a/consensus/polybft/stake_manager.go
+++ b/consensus/polybft/stake_manager.go
@@ -185,6 +185,7 @@ func (s *stakeManager) init(dbTx *bolt.Tx) error {
 	}
 
 	checkForBalanceChanges := true
+
 	eventsCount := len(powerExponentUpdatedEvents)
 	if eventsCount > 0 {
 		err = s.updateOnPowerExponentEvent(
@@ -305,6 +306,7 @@ func (s *stakeManager) updateWithReceipts(
 	}
 
 	blockNumber := blockHeader.Number
+
 	for addr, data := range fullValidatorSet.Validators {
 		if data.BlsKey == nil {
 			blsKey, err := s.getBlsKey(data.Address)
@@ -325,7 +327,8 @@ func (s *stakeManager) updateWithReceipts(
 // UpdateValidatorSet returns an updated list of validators
 // based on balance change (transfer) events from HydraChain contract
 func (s *stakeManager) UpdateValidatorSet(
-	epoch uint64, oldValidators validator.AccountSet) (*validator.ValidatorSetDelta, error) {
+	epoch uint64, oldValidators validator.AccountSet,
+) (*validator.ValidatorSetDelta, error) {
 	s.logger.Info("Calculating validators set update...", "epoch", epoch)
 
 	fullValidatorSet, err := s.state.StakeStore.getFullValidatorSet(nil)
@@ -358,7 +361,7 @@ func (s *stakeManager) UpdateValidatorSet(
 		oldActiveMap[validator.Address] = validator
 		// remove existing validators from the validators list if they did not make it to the list
 		if _, exists := addressesSet[validator.Address]; !exists {
-			removedBitmap.Set(uint64(i))
+			removedBitmap.Set(uint64(i)) //nolint:gosec
 		}
 	}
 
@@ -405,6 +408,7 @@ func (s *stakeManager) UpdateValidatorSet(
 // getBlsKey returns bls key for validator from the supernet contract
 func (s *stakeManager) getBlsKey(address types.Address) (*bls.PublicKey, error) {
 	header := s.blockchain.CurrentHeader()
+
 	systemState, err := s.getSystemStateForBlock(header)
 	if err != nil {
 		return nil, err
@@ -478,6 +482,7 @@ func (s *stakeManager) ProcessLog(header *types.Header, log *ethgo.Log, dbTx *bo
 
 	// Check if it is a BalanceChanged event
 	var balanceChangedEvent contractsapi.BalanceChangedEvent
+
 	doesMatch, err := balanceChangedEvent.ParseLog(log)
 	if err != nil {
 		return err
@@ -492,6 +497,7 @@ func (s *stakeManager) ProcessLog(header *types.Header, log *ethgo.Log, dbTx *bo
 	} else {
 		// If not BalanceChanged, check for PowerExponentUpdated event
 		var powerExponentUpdatedEvent contractsapi.PowerExponentUpdatedEvent
+
 		doesMatch, err = powerExponentUpdatedEvent.ParseLog(log)
 		if err != nil {
 			return err
@@ -589,7 +595,9 @@ func (sc *validatorStakeMap) setStake(
 		stakedBalance,
 		&BigNumDecimal{Numerator: exponent, Denominator: DefaultDenominator},
 	)
+
 	isActive := votingPower.Cmp(bigZero) > 0
+
 	if metadata, exists := (*sc)[address]; exists {
 		metadata.VotingPower = votingPower
 		metadata.IsActive = isActive

--- a/consensus/polybft/state.go
+++ b/consensus/polybft/state.go
@@ -45,7 +45,7 @@ type State struct {
 }
 
 // newState creates new instance of State
-func newState(path string, logger hclog.Logger, closeCh chan struct{}) (*State, error) {
+func newState(path string, _ hclog.Logger, closeCh chan struct{}) (*State, error) {
 	db, err := bolt.Open(path, 0666, nil)
 	if err != nil {
 		return nil, err
@@ -74,12 +74,15 @@ func (s *State) initStorages() error {
 		if err := s.CheckpointStore.initialize(tx); err != nil {
 			return err
 		}
+
 		if err := s.EpochStore.initialize(tx); err != nil {
 			return err
 		}
+
 		if err := s.ProposerSnapshotStore.initialize(tx); err != nil {
 			return err
 		}
+
 		if err := s.StakeStore.initialize(tx); err != nil {
 			return err
 		}

--- a/consensus/polybft/state_transaction.go
+++ b/consensus/polybft/state_transaction.go
@@ -25,22 +25,23 @@ func decodeStateTransaction(txData []byte) (contractsapi.StateTransactionInput, 
 		obj                    contractsapi.StateTransactionInput
 	)
 
-	if bytes.Equal(sig, commitEpochFn.Sig()) {
+	switch {
+	case bytes.Equal(sig, commitEpochFn.Sig()):
 		// commit epoch
 		obj = &contractsapi.CommitEpochHydraChainFn{}
-	} else if bytes.Equal(sig, fundRewardWalletFn.Sig()) {
+	case bytes.Equal(sig, fundRewardWalletFn.Sig()):
 		// fund reward wallet
 		obj = &contractsapi.FundRewardWalletFn{}
-	} else if bytes.Equal(sig, distributeRewardsFn.Sig()) {
+	case bytes.Equal(sig, distributeRewardsFn.Sig()):
 		// distribute rewards
 		obj = &contractsapi.DistributeRewardsForHydraStakingFn{}
-	} else if bytes.Equal(sig, distributeVaultFundsFn.Sig()) {
+	case bytes.Equal(sig, distributeVaultFundsFn.Sig()):
 		// distribute vault funds
 		obj = &contractsapi.DistributeDAOIncentiveHydraChainFn{}
-	} else if bytes.Equal(sig, SyncValidatorsDataFn.Sig()) {
+	case bytes.Equal(sig, SyncValidatorsDataFn.Sig()):
 		// sync the validators voting power data
 		obj = &contractsapi.SyncValidatorsDataHydraChainFn{}
-	} else {
+	default:
 		return nil, fmt.Errorf("unknown state transaction")
 	}
 

--- a/consensus/polybft/validator/test_helpers.go
+++ b/consensus/polybft/validator/test_helpers.go
@@ -166,13 +166,14 @@ func (v *TestValidator) ParamsValidator() *GenesisValidator {
 		1,
 		signer.DomainHydraChain,
 	)
+
 	if err != nil {
-		panic(fmt.Sprintf("BUG: failed to sign validator params: %v", err))
+		panic(fmt.Sprintf("BUG: failed to sign validator params: %v", err)) //nolint:gocritic
 	}
 
 	signatureBytes, err := blsSignature.Marshal()
 	if err != nil {
-		panic(fmt.Sprintf("BUG: failed to marshal validator params signature: %v", err))
+		panic(fmt.Sprintf("BUG: failed to marshal validator params signature: %v", err)) //nolint:gocritic
 	}
 
 	return &GenesisValidator{
@@ -246,7 +247,7 @@ func CreateValidatorSetDelta(oldValidatorSet, newValidatorSet AccountSet) (*Vali
 
 	removedValsBitmap := bitmap.Bitmap{}
 	for _, i := range removedValidators {
-		removedValsBitmap.Set(uint64(i))
+		removedValsBitmap.Set(uint64(i)) //nolint:gosec
 	}
 
 	delta := &ValidatorSetDelta{

--- a/consensus/polybft/validator/validator_metadata.go
+++ b/consensus/polybft/validator/validator_metadata.go
@@ -301,15 +301,15 @@ func (as AccountSet) GetFilteredValidators(bitmap bitmap.Bitmap) (AccountSet, er
 	}
 
 	if bitmap.Len() > uint64(len(as)) {
-		for i := len(as); i < int(bitmap.Len()); i++ {
-			if bitmap.IsSet(uint64(i)) {
+		for i := len(as); i < int(bitmap.Len()); i++ { //nolint:gosec
+			if bitmap.IsSet(uint64(i)) { //nolint:gosec
 				return filteredValidators, errors.New("invalid bitmap filter provided")
 			}
 		}
 	}
 
 	for i, validator := range as {
-		if bitmap.IsSet(uint64(i)) {
+		if bitmap.IsSet(uint64(i)) { //nolint:gosec
 			filteredValidators = append(filteredValidators, validator)
 		}
 	}
@@ -333,7 +333,7 @@ func (as AccountSet) ApplyDelta(validatorsDelta *ValidatorSetDelta) (AccountSet,
 		// If a validator is not in the Removed set, or it is in the Removed set
 		// but it exists in the Added set as well (which should never happen),
 		// the validator should remain in the validator set.
-		if !validatorsDelta.Removed.IsSet(uint64(i)) ||
+		if !validatorsDelta.Removed.IsSet(uint64(i)) || //nolint:gosec
 			validatorsDelta.Added.ContainsAddress(validator.Address) {
 			validators = append(validators, validator)
 		}
@@ -379,7 +379,7 @@ func (as AccountSet) ExtractUpdatedValidatorsVotingPower(
 		// If a validator is removed, then append it.
 		// Otherwise, check if the validator is in the added or updated list
 		// because we are looking only for the updated ones.
-		if validatorsDelta.Removed.IsSet(uint64(i)) {
+		if validatorsDelta.Removed.IsSet(uint64(i)) { //nolint:gosec
 			updatedValidatorsPower = append(updatedValidatorsPower, formatValidatorPower(validator))
 		} else if validatorsDelta.Added.ContainsAddress(validator.Address) ||
 			validatorsDelta.Updated.ContainsAddress(validator.Address) {

--- a/contracts/system_addresses.go
+++ b/contracts/system_addresses.go
@@ -31,7 +31,8 @@ var (
 	HydraDelegationContractV1 = types.StringToAddress("0x1071")
 	// VestingManagerFactoryContract is an address of the VestingManagerFactory's proxy contract on the chain
 	VestingManagerFactoryContract = types.StringToAddress("0x108")
-	// VestingManagerFactoryContractV1 is an address of the VestingManagerFactoryContract's implementation contract deployed on the chain
+	// VestingManagerFactoryContractV1 is an address of the VestingManagerFactoryContract's implementation contract
+	// deployed on the chain
 	VestingManagerFactoryContractV1 = types.StringToAddress("0x1081")
 	// APRCalculatorContract is an address of the APRCalculator's proxy contract on the chain
 	APRCalculatorContract = types.StringToAddress("0x109")

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,8 @@
 module github.com/0xPolygon/polygon-edge
 
-go 1.20
+go 1.21
+
+toolchain go1.21.13
 
 require (
 	github.com/btcsuite/btcd v0.22.1

--- a/go.sum
+++ b/go.sum
@@ -3,6 +3,7 @@ cloud.google.com/go v0.31.0/go.mod h1:aQUYkXzVsufM+DwF1aE+0xfcU+56JwCaLick0ClmMT
 cloud.google.com/go v0.34.0/go.mod h1:aQUYkXzVsufM+DwF1aE+0xfcU+56JwCaLick0ClmMTw=
 cloud.google.com/go v0.37.0/go.mod h1:TS1dMSSfndXH133OKGwekG838Om/cQT0BUHV3HcBgoo=
 cloud.google.com/go v0.112.2 h1:ZaGT6LiG7dBzi6zNOvVZwacaXlmf3lRqnC4DQzqyRQw=
+cloud.google.com/go v0.112.2/go.mod h1:iEqjp//KquGIJV/m+Pk3xecgKNhV+ry+vVTsy4TbDms=
 cloud.google.com/go/auth v0.3.0 h1:PRyzEpGfx/Z9e8+lHsbkoUVXD0gnu4MNmm7Gp8TQNIs=
 cloud.google.com/go/auth v0.3.0/go.mod h1:lBv6NKTWp8E3LPzmO1TbiiRKc4drLOfHsgmlH9ogv5w=
 cloud.google.com/go/auth/oauth2adapt v0.2.2 h1:+TTV8aXpjeChS9M+aTtN/TjdQnzJvmzKFt//oWu7HX4=
@@ -134,6 +135,7 @@ github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc/go.mod h1:J7Y8Yc
 github.com/davidlazar/go-crypto v0.0.0-20200604182044-b73af7476f6c h1:pFUpOrbxDR6AkioZ1ySsx5yxlDQZ8stG2b88gTPxgJU=
 github.com/davidlazar/go-crypto v0.0.0-20200604182044-b73af7476f6c/go.mod h1:6UhI8N9EjYm1c2odKpFpAYeR8dsBeM7PtzQhRgxRr9U=
 github.com/decred/dcrd/crypto/blake256 v1.0.1 h1:7PltbUIQB7u/FfZ39+DGa/ShuMyJ5ilcvdfma9wOH6Y=
+github.com/decred/dcrd/crypto/blake256 v1.0.1/go.mod h1:2OfgNZ5wDpcsFmHmCK5gZTPcCXqlm2ArzUIkw9czNJo=
 github.com/decred/dcrd/dcrec/secp256k1/v4 v4.2.0 h1:8UrgZ3GkP4i/CLijOJx79Yu+etlyjdBU4sfcs2WYQMs=
 github.com/decred/dcrd/dcrec/secp256k1/v4 v4.2.0/go.mod h1:v57UDF4pDQJcEfFUCRop3lJL149eHGSe9Jvczhzjo/0=
 github.com/dgryski/go-farm v0.0.0-20190423205320-6a90982ecee2 h1:tdlZCpZ/P9DhczCTSixgIKmwPv6+wP5DGjqLYw5SUiA=
@@ -177,6 +179,7 @@ github.com/fsnotify/fsnotify v1.4.7/go.mod h1:jwhsz4b93w/PPRr/qN1Yymfu8t87LnFCMo
 github.com/fsnotify/fsnotify v1.4.9/go.mod h1:znqG4EE+3YCdAaPaxE2ZRY/06pZUdp0tY4IgpuI1SZQ=
 github.com/fsnotify/fsnotify v1.5.4/go.mod h1:OVB6XrOHzAwXMpEM7uPOzcehqUV2UqJxmVXmkdnm1bU=
 github.com/fsnotify/fsnotify v1.6.0 h1:n+5WquG0fcWoWp6xPWfHdbskMCQaFnG6PfBrh1Ky4HY=
+github.com/fsnotify/fsnotify v1.6.0/go.mod h1:sl3t1tCWJFWoRz9R8WJCbQihKKwmorjAbSClcnxKAGw=
 github.com/ghodss/yaml v1.0.0/go.mod h1:4dBDuWmgqj2HViK6kFavaiC9ZROes6MMH2rRYeMEF04=
 github.com/gliderlabs/ssh v0.1.1/go.mod h1:U7qILu1NlMHj9FlMhZLlkCdDnU1DBEAqr0aevW3Awn0=
 github.com/go-errors/errors v1.0.1/go.mod h1:f4zRHt4oKfwPJE5k8C9vpYG+aDHdBFUsgrm6/TyX73Q=
@@ -196,6 +199,7 @@ github.com/go-task/slim-sprig v0.0.0-20210107165309-348f09dbbbc0/go.mod h1:fyg78
 github.com/go-task/slim-sprig v0.0.0-20230315185526-52ccab3ef572 h1:tfuBGBXKqDEevZMzYi5KSi8KkcZtzBcTgAUUtapy0OI=
 github.com/go-task/slim-sprig v0.0.0-20230315185526-52ccab3ef572/go.mod h1:9Pwr4B2jHnOSGXyyzV8ROjYa2ojvAY6HCGYYfMoC3Ls=
 github.com/go-test/deep v1.0.2 h1:onZX1rnHT3Wv6cqNgYyFOOlgVKJrksuCMCRvJStbMYw=
+github.com/go-test/deep v1.0.2/go.mod h1:wGDj63lr65AM2AQyKZd/NYHGb0R+1RLqB8NKt3aSFNA=
 github.com/go-toolsmith/astcopy v1.0.2 h1:YnWf5Rnh1hUudj11kei53kI57quN/VH6Hp1n+erozn0=
 github.com/go-toolsmith/astcopy v1.0.2/go.mod h1:4TcEdbElGc9twQEYpVo/aieIXfHhiuLh4aLAck6dO7Y=
 github.com/go-toolsmith/astequal v1.0.2/go.mod h1:9Ai4UglvtR+4up+bAD4+hCj7iTo4m/OXVTSLnCyTAx4=
@@ -249,6 +253,7 @@ github.com/google/go-cmp v0.5.4/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/
 github.com/google/go-cmp v0.5.5/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.5.8/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
 github.com/google/go-cmp v0.6.0 h1:ofyhxvXcZhMsU5ulbFiLKl/XBFqE1GSq7atu8tAmTRI=
+github.com/google/go-cmp v0.6.0/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
 github.com/google/go-github v17.0.0+incompatible/go.mod h1:zLgOLi98H3fifZn+44m+umXrS52loVEgC2AApnigrVQ=
 github.com/google/go-querystring v1.0.0/go.mod h1:odCYkC5MyYFN7vkCjXpyrEuKhc/BUO6wN/zVPAxq5ck=
 github.com/google/gofuzz v1.0.0/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/M65Eg=
@@ -278,6 +283,7 @@ github.com/gopherjs/gopherjs v0.0.0-20181017120253-0766667cb4d1/go.mod h1:wJfORR
 github.com/gorilla/websocket v1.5.1 h1:gmztn0JnHVt9JZquRuzLw3g4wouNVzKL15iLr/zn/QY=
 github.com/gorilla/websocket v1.5.1/go.mod h1:x3kM2JMyaluk02fnUJpQuwD2dCS5NDG2ZHL0uE0tcaY=
 github.com/gotestyourself/gotestyourself v2.2.0+incompatible h1:AQwinXlbQR2HvPjQZOmDhRqsv5mZf+Jb1RnSLxcqZcI=
+github.com/gotestyourself/gotestyourself v2.2.0+incompatible/go.mod h1:zZKM6oeNM8k+FRljX1mnzVYeS8wiGgQyvST1/GafPbY=
 github.com/gregjones/httpcache v0.0.0-20180305231024-9cad4c3443a7/go.mod h1:FecbI9+v66THATjSRHfNgh1IVFe/9kFxbXtjV0ctIMA=
 github.com/grpc-ecosystem/grpc-gateway v1.5.0/go.mod h1:RSKVYQBd5MCa4OVpNdGskqpgL2+G+NZTnrVHpWWfpdw=
 github.com/hashicorp/errwrap v1.0.0/go.mod h1:YH+1FKiLXxHSkmPseP+kNlulaMuP3n2brvKWEqk/Jc4=
@@ -309,6 +315,7 @@ github.com/hashicorp/go-sockaddr v1.0.2 h1:ztczhD1jLxIRjVejw8gFomI1BQZOe2WoVOu0S
 github.com/hashicorp/go-sockaddr v1.0.2/go.mod h1:rB4wwRAUzs07qva3c5SdrY/NEtAUjGlgmH/UkBUC97A=
 github.com/hashicorp/go-uuid v1.0.0/go.mod h1:6SBZvOh/SIDV7/2o3Jml5SYk/TvGqwFJ/bN7x4byOro=
 github.com/hashicorp/go-uuid v1.0.3 h1:2gKiV6YVmrJ1i2CKKa9obLvRieoRGviZFL26PcT/Co8=
+github.com/hashicorp/go-uuid v1.0.3/go.mod h1:6SBZvOh/SIDV7/2o3Jml5SYk/TvGqwFJ/bN7x4byOro=
 github.com/hashicorp/golang-lru v0.5.0/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ4Ao+sR/qLZy8=
 github.com/hashicorp/golang-lru v1.0.2 h1:dV3g9Z/unq5DpblPpw+Oqcv4dU/1omnb4Ok8iPY6p1c=
 github.com/hashicorp/golang-lru v1.0.2/go.mod h1:iADmTwqILo4mZ8BN3D2Q6+9jd8WM5uGBxy+E8yxSoD4=
@@ -365,13 +372,16 @@ github.com/kr/logfmt v0.0.0-20140226030751-b84e30acd515/go.mod h1:+0opPa2QZZtGFB
 github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORNo=
 github.com/kr/pretty v0.2.1/go.mod h1:ipq/a2n7PKx3OHsz4KJII5eveXtPO4qwEXGdVfWzfnI=
 github.com/kr/pretty v0.3.1 h1:flRD4NNwYAUpkphVc1HcthR4KEIFJ65n8Mw5qdRn3LE=
+github.com/kr/pretty v0.3.1/go.mod h1:hoEshYVHaxMs3cyo3Yncou5ZscifuDolrwPKZanG3xk=
 github.com/kr/pty v1.1.1/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=
 github.com/kr/pty v1.1.3/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=
 github.com/kr/text v0.1.0/go.mod h1:4Jbv+DJW3UT/LiOwJeYQe1efqtUx/iVham/4vfdArNI=
 github.com/kr/text v0.2.0 h1:5Nx0Ya0ZqY2ygV366QzturHI13Jq95ApcVaJBhpS+AY=
+github.com/kr/text v0.2.0/go.mod h1:eLer722TekiGuMkidMxC/pM04lWEeraHUUmBw8l2grE=
 github.com/leanovate/gopter v0.2.9 h1:fQjYxZaynp97ozCzfOyOuAGOU4aU/z37zf/tOujFk7c=
 github.com/leanovate/gopter v0.2.9/go.mod h1:U2L/78B+KVFIx2VmW6onHJQzXtFb+p5y3y2Sh+Jxxv8=
 github.com/lib/pq v1.10.2 h1:AqzbZs4ZoCBp+GtejcpCpcxM3zlSMx29dXbUSeVtJb8=
+github.com/lib/pq v1.10.2/go.mod h1:AlVN5x4E4T544tWzH6hKfbfQvm3HdbOxrmggDNAPY9o=
 github.com/libp2p/go-buffer-pool v0.1.0 h1:oK4mSFcQz7cTQIfqbe4MIj9gLW+mnanjyFtc6cdF0Y8=
 github.com/libp2p/go-buffer-pool v0.1.0/go.mod h1:N+vh8gMqimBzdKkSMVuydVDq+UV5QTWy5HSiZacSbPg=
 github.com/libp2p/go-cidranger v1.1.0 h1:ewPN8EZ0dd1LSnrtuwd4709PXVcITVeuwbag38yPW7c=
@@ -387,6 +397,7 @@ github.com/libp2p/go-libp2p-kbucket v0.6.3/go.mod h1:RCseT7AH6eJWxxk2ol03xtP9pEH
 github.com/libp2p/go-libp2p-pubsub v0.10.1 h1:/RqOZpEtAolsr8/9CC8KqROJSOZeu7lK7fPftn4MwNg=
 github.com/libp2p/go-libp2p-pubsub v0.10.1/go.mod h1:1OxbaT/pFRO5h+Dpze8hdHQ63R0ke55XTs6b6NwLLkw=
 github.com/libp2p/go-libp2p-testing v0.12.0 h1:EPvBb4kKMWO29qP4mZGyhVzUyR25dvfUIK5WDu6iPUA=
+github.com/libp2p/go-libp2p-testing v0.12.0/go.mod h1:KcGDRXyN7sQCllucn1cOOS+Dmm7ujhfEyXQL5lvkcPg=
 github.com/libp2p/go-msgio v0.3.0 h1:mf3Z8B1xcFN314sWX+2vOTShIE0Mmn2TXn3YCUQGNj0=
 github.com/libp2p/go-msgio v0.3.0/go.mod h1:nyRM819GmVaF9LX3l03RMh10QdOroF++NBbxAb0mmDM=
 github.com/libp2p/go-nat v0.2.0 h1:Tyz+bUFAYqGyJ/ppPPymMGbIgNRH+WqC5QrT5fKrrGk=
@@ -494,6 +505,7 @@ github.com/onsi/gomega v1.10.1/go.mod h1:iN09h71vgCQne3DLsj+A5owkum+a2tYe+TOCB1y
 github.com/onsi/gomega v1.17.0/go.mod h1:HnhC7FXeEQY45zxNK3PPoIUhzk/80Xly9PcubAlGdZY=
 github.com/onsi/gomega v1.19.0/go.mod h1:LY+I3pBVzYsTBU1AnDwOSxaYi9WoWiqgwooUqq9yPro=
 github.com/onsi/gomega v1.27.10 h1:naR28SdDFlqrG6kScpT8VWpu1xWY5nJRCF3XaYyBjhI=
+github.com/onsi/gomega v1.27.10/go.mod h1:RsS8tutOdbdgzbPtzzATp12yT7kM5I5aElG3evPbQ0M=
 github.com/opencontainers/go-digest v1.0.0 h1:apOUWs51W5PlhuyGyz9FCeeBIOUDA/6nW8Oi/yOhh5U=
 github.com/opencontainers/go-digest v1.0.0/go.mod h1:0JzlMkj0TRzQZfJkVvzbP0HBR3IKzErnv2BNG4W4MAM=
 github.com/opencontainers/image-spec v1.0.2 h1:9yCKha/T5XdGtO0q9Q9a6T5NUCsTn/DrBg0D7ufOcFM=
@@ -571,6 +583,7 @@ github.com/richardartoul/molecule v1.0.1-0.20221107223329-32cfee06a052 h1:Qp27Id
 github.com/richardartoul/molecule v1.0.1-0.20221107223329-32cfee06a052/go.mod h1:uvX/8buq8uVeiZiFht+0lqSLBHF+uGV8BrTv8W/SIwk=
 github.com/rogpeppe/go-internal v1.3.0/go.mod h1:M8bDsm7K2OlrFYOpmOWEs/qY81heoFRclV5y23lUDJ4=
 github.com/rogpeppe/go-internal v1.10.0 h1:TMyTOH3F/DB16zRVcYyreMH6GnZZrwQVAoYjRBZyWFQ=
+github.com/rogpeppe/go-internal v1.10.0/go.mod h1:UQnix2H7Ngw/k4C5ijL5+65zddjncjaFoBhdsK/akog=
 github.com/russross/blackfriday v1.5.2/go.mod h1:JO/DiYxRf+HjHt06OyowR9PTA263kcR/rfWxYHBV53g=
 github.com/russross/blackfriday/v2 v2.0.1/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
 github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
@@ -688,6 +701,7 @@ go.opentelemetry.io/otel v1.24.0/go.mod h1:W7b9Ozg4nkF5tWI5zsXkaKKDjdVjpD4oAt9Qi
 go.opentelemetry.io/otel/metric v1.24.0 h1:6EhoGWWK28x1fbpA4tYTOWBkPefTDQnb8WSGXlc88kI=
 go.opentelemetry.io/otel/metric v1.24.0/go.mod h1:VYhLe1rFfxuTXLgj4CBiyz+9WYBA8pNGJgDcSFRKBco=
 go.opentelemetry.io/otel/sdk v1.24.0 h1:YMPPDNymmQN3ZgczicBY3B6sf9n62Dlj9pWD3ucgoDw=
+go.opentelemetry.io/otel/sdk v1.24.0/go.mod h1:KVrIYw6tEubO9E96HQpcmpTKDVn9gdv35HoYiQWGDFg=
 go.opentelemetry.io/otel/trace v1.24.0 h1:CsKnnL4dUAr/0llH9FKuc698G04IrpWV0MQA/Y1YELI=
 go.opentelemetry.io/otel/trace v1.24.0/go.mod h1:HPc3Xr/cOApsBI154IU0OI0HJexz+aw5uPdbs3UCjNU=
 go.uber.org/atomic v1.6.0/go.mod h1:sABNBOSYdrvTF6hTgEIbc7YasKWGhgEQZyfxyTvoXHQ=
@@ -701,6 +715,7 @@ go.uber.org/fx v1.20.1 h1:zVwVQGS8zYvhh9Xxcu4w1M6ESyeMzebzj2NbSayZ4Mk=
 go.uber.org/fx v1.20.1/go.mod h1:iSYNbHf2y55acNCwCXKx7LbWb5WG1Bnue5RDXz1OREg=
 go.uber.org/goleak v1.1.11-0.20210813005559-691160354723/go.mod h1:cwTWslyiVhfpKIDGSZEM2HlOvcqm+tG4zioyIeLoqMQ=
 go.uber.org/goleak v1.3.0 h1:2K3zAYmnTNqV73imy9J1T3WC+gmCePx2hEGkimedGto=
+go.uber.org/goleak v1.3.0/go.mod h1:CoHD4mav9JJNrW/WLlf7HGZPjdw8EucARQHekz1X6bE=
 go.uber.org/mock v0.3.0 h1:3mUxI1No2/60yUYax92Pt8eNOEecx2D3lcXZh2NEZJo=
 go.uber.org/mock v0.3.0/go.mod h1:a6FSlNadKUHUa9IP5Vyt1zh4fC7uAwxMutEAscFbkZc=
 go.uber.org/multierr v1.5.0/go.mod h1:FeouvMocqHpRaaGuG9EjoKcStLC43Zu/fmqdUMPcKYU=
@@ -978,6 +993,7 @@ gotest.tools/v3 v3.0.2 h1:kG1BFyqVHuQoVQiR1bWGnfz/fmHvvuiSPIV7rvl360E=
 gotest.tools/v3 v3.0.2/go.mod h1:3SzNCllyD9/Y+b5r9JIKQ474KzkZyqLqEfYqMsX94Bk=
 grpc.go4.org v0.0.0-20170609214715-11d0a25b4919/go.mod h1:77eQGdRu53HpSqPFJFmuJdjuHRquDANNeA4x7B8WQ9o=
 honnef.co/go/gotraceui v0.2.0 h1:dmNsfQ9Vl3GwbiVD7Z8d/osC6WtGGrasyrC2suc4ZIQ=
+honnef.co/go/gotraceui v0.2.0/go.mod h1:qHo4/W75cA3bX0QQoSvDjbJa4R8mAyyFjbWAj63XElc=
 honnef.co/go/tools v0.0.0-20180728063816-88497007e858/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=
 honnef.co/go/tools v0.0.0-20190102054323-c2f93a96b099/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=
 honnef.co/go/tools v0.0.0-20190106161140-3f1c8253044a/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=

--- a/helper/common/common.go
+++ b/helper/common/common.go
@@ -94,7 +94,7 @@ func BigMin(x, y *big.Int) *big.Int {
 func ConvertUnmarshalledUint(x interface{}) (uint64, error) {
 	switch tx := x.(type) {
 	case float64:
-		return uint64(roundFloat(tx)), nil
+		return uint64(roundFloat(tx)), nil //nolint:gosec
 	case string:
 		v, err := ParseUint64orHex(&tx)
 		if err != nil {

--- a/helper/common/encoding.go
+++ b/helper/common/encoding.go
@@ -53,7 +53,7 @@ func ParseUint256(val *uint64) *big.Int {
 		return nil
 	}
 
-	return new(big.Int).SetUint64(*val)	
+	return new(big.Int).SetUint64(*val)
 }
 
 func ParseBytes(val *string) ([]byte, error) {

--- a/jsonrpc/throttling_test.go
+++ b/jsonrpc/throttling_test.go
@@ -22,74 +22,61 @@ func TestThrottling(t *testing.T) {
 		}
 	}
 
-	wg := sync.WaitGroup{}
+	var wg sync.WaitGroup
+
+	startCh := make(chan struct{})
+
+	// Function to attempt a request with context
+	attemptRequest := func(ctx context.Context, value int, sleep time.Duration, expectError bool) {
+		defer wg.Done()
+		<-startCh
+
+		res, err := th.AttemptRequest(ctx, sfn(value, sleep))
+		if expectError {
+			require.ErrorIs(t, err, errRequestLimitExceeded)
+			assert.Nil(t, res)
+		} else {
+			require.NoError(t, err)
+
+			if intValue, ok := res.(int); ok {
+				assert.Equal(t, value, intValue)
+			} else {
+				assert.Fail(t, "type assertion failed")
+			}
+		}
+	}
+
 	wg.Add(9)
 
-	go func() {
-		defer wg.Done()
-
-		res, err := th.AttemptRequest(context.Background(), sfn(100, time.Millisecond*500))
-
-		require.NoError(t, err)
-		assert.Equal(t, 100, res.(int)) //nolint
-	}()
-
+	// Start goroutines
+	go attemptRequest(context.Background(), 100, time.Millisecond*500, false)
 	time.Sleep(time.Millisecond * 100)
 
 	for i := 2; i <= 5; i++ {
-		go func() {
-			defer wg.Done()
-
-			res, err := th.AttemptRequest(context.Background(), sfn(100, time.Millisecond*1000))
-
-			require.NoError(t, err)
-			assert.Equal(t, 100, res.(int)) //nolint
-		}()
+		go attemptRequest(context.Background(), 100, time.Millisecond*1000, false)
 	}
 
 	go func() {
 		time.Sleep(time.Millisecond * 150)
-
-		defer wg.Done()
-
-		res, err := th.AttemptRequest(context.Background(), sfn(100, time.Millisecond*100))
-
-		require.ErrorIs(t, err, errRequestLimitExceeded)
-		assert.Nil(t, res)
+		attemptRequest(context.Background(), 100, time.Millisecond*100, true)
 	}()
 
 	go func() {
 		time.Sleep(time.Millisecond * 620)
-
-		defer wg.Done()
-
-		res, err := th.AttemptRequest(context.Background(), sfn(10, time.Millisecond*100))
-
-		require.NoError(t, err)
-		assert.Equal(t, 10, res.(int)) //nolint
+		attemptRequest(context.Background(), 10, time.Millisecond*100, false)
 	}()
 
 	go func() {
 		time.Sleep(time.Millisecond * 640)
-
-		defer wg.Done()
-
-		res, err := th.AttemptRequest(context.Background(), sfn(100, time.Millisecond*100))
-
-		require.ErrorIs(t, err, errRequestLimitExceeded)
-		assert.Nil(t, res)
+		attemptRequest(context.Background(), 100, time.Millisecond*100, true)
 	}()
 
 	go func() {
 		time.Sleep(time.Millisecond * 1000)
-
-		defer wg.Done()
-
-		res, err := th.AttemptRequest(context.Background(), sfn(1, time.Millisecond*100))
-
-		require.NoError(t, err)
-		assert.Equal(t, 1, res.(int)) //nolint
+		attemptRequest(context.Background(), 1, time.Millisecond*100, false)
 	}()
 
+	// Start all requests
+	close(startCh)
 	wg.Wait()
 }

--- a/network/server_test.go
+++ b/network/server_test.go
@@ -187,6 +187,7 @@ func TestPeerEvent_EmitAndSubscribe(t *testing.T) {
 			id, event := getIDAndEventType(i)
 			server.emitEvent(id, event)
 		}
+
 		for i := 0; i < count; i++ {
 			received := <-receiver
 			id, event := getIDAndEventType(i)
@@ -653,6 +654,7 @@ func TestRunDial(t *testing.T) {
 				t.Fatalf("Unable to join peer, %v", joinErr)
 			}
 		}
+
 		closeServers(servers...)
 	})
 
@@ -673,6 +675,7 @@ func TestRunDial(t *testing.T) {
 				assert.Error(t, joinErr)
 			}
 		}
+
 		closeServers(servers...)
 	})
 
@@ -769,9 +772,8 @@ func TestSubscribe(t *testing.T) {
 		server := setupServer(t, true)
 
 		ctx, cancel := context.WithCancel(context.Background())
-		t.Cleanup(func() {
-			cancel()
-		})
+
+		t.Cleanup(cancel)
 
 		eventCh := toChannel(t, ctx, server)
 
@@ -808,9 +810,8 @@ func TestSubscribe(t *testing.T) {
 		server := setupServer(t, false)
 
 		ctx, cancel := context.WithCancel(context.Background())
-		t.Cleanup(func() {
-			cancel()
-		})
+
+		t.Cleanup(cancel)
 
 		eventCh := toChannel(t, ctx, server)
 

--- a/price-oracle/price_feed.go
+++ b/price-oracle/price_feed.go
@@ -80,6 +80,7 @@ func getCoingeckoPrice(apiKey string) (*big.Int, error) {
 	}
 
 	var priceData PriceDataCoinGecko
+
 	err = json.Unmarshal(body, &priceData)
 	if err != nil {
 		return nil, fmt.Errorf("failed to unmarshal response: %w", err)

--- a/price-oracle/price_oracle.go
+++ b/price-oracle/price_oracle.go
@@ -200,6 +200,7 @@ func (p *PriceOracle) shouldExecuteVote(header *types.Header) (bool, error) {
 
 	// then check if the contract is in a proper state to vote
 	dayNumber := calcDayNumber(header.Timestamp)
+
 	shouldVote, falseReason, err := state.shouldVote(dayNumber)
 	if err != nil {
 		return false, err
@@ -341,7 +342,7 @@ func isVotingTime(timestamp uint64) bool {
 
 // isBlockOlderThan checks if the block is older than the given number of minutes
 func isBlockOlderThan(header *types.Header, minutes int64) bool {
-	return time.Now().UTC().Unix()-int64(header.Timestamp) > minutes*60
+	return time.Now().UTC().Unix()-int64(header.Timestamp) > minutes*60 //nolint:gosec
 }
 
 func calcDayNumber(timestamp uint64) uint64 {

--- a/price-oracle/price_oracle_test.go
+++ b/price-oracle/price_oracle_test.go
@@ -18,6 +18,10 @@ import (
 	"github.com/umbracle/ethgo"
 )
 
+func setup() {
+	hasExecutedForDay = make(map[uint64]bool)
+}
+
 func TestIsValidator(t *testing.T) {
 	mockPolybftBackend := new(MockPolybftBackend)
 	validators := validator.NewTestValidatorsWithAliases(
@@ -86,6 +90,7 @@ func TestIsValidator(t *testing.T) {
 			isValidator, err := priceOracle.isValidator(tt.block)
 
 			require.Equal(t, tt.expectedIsValidator, isValidator)
+
 			if tt.expectedError != nil {
 				require.EqualError(t, err, tt.expectedError.Error())
 			} else {
@@ -412,6 +417,7 @@ func TestShouldExecuteVote(t *testing.T) {
 
 			// Assert the results
 			require.Equal(t, tt.expectedResult, result)
+
 			if tt.expectedError != nil {
 				require.EqualError(t, err, tt.expectedError.Error())
 			} else {
@@ -480,18 +486,18 @@ func TestVote(t *testing.T) {
 			require.Equal(
 				t,
 				expectedPrice.String(),
-				event["price"].(*big.Int).String(),
-			) //nolint:forcetypeassert
+				event["price"].(*big.Int).String(), //nolint:forcetypeassert
+			)
 			require.Equal(
 				t,
 				account.Ecdsa.Address().String(),
-				event["validator"].(ethgo.Address).String(),
-			) //nolint:forcetypeassert
+				event["validator"].(ethgo.Address).String(), //nolint:forcetypeassert
+			)
 			require.Equal(
 				t,
 				big.NewInt(1),
-				event["day"].(*big.Int),
-			) //nolint:forcetypeassert
+				event["day"].(*big.Int), //nolint:forcetypeassert
+			)
 			foundVoteLog = true
 		}
 	}
@@ -643,18 +649,18 @@ func TestExecuteVote(t *testing.T) {
 			require.Equal(
 				t,
 				expectedPrice.String(),
-				event["price"].(*big.Int).String(),
-			) //nolint:forcetypeassert
+				event["price"].(*big.Int).String(), //nolint:forcetypeassert
+			)
 			require.Equal(
 				t,
 				account.Ecdsa.Address().String(),
-				event["validator"].(ethgo.Address).String(),
-			) //nolint:forcetypeassert
+				event["validator"].(ethgo.Address).String(), //nolint:forcetypeassert
+			)
 			require.Equal(
 				t,
 				big.NewInt(1),
-				event["day"].(*big.Int),
-			) //nolint:forcetypeassert
+				event["day"].(*big.Int), //nolint:forcetypeassert
+			)
 			foundVoteLog = true
 		}
 	}
@@ -672,6 +678,8 @@ func TestExecuteVote(t *testing.T) {
 }
 
 func TestExecuteVote_PriceFeedError(t *testing.T) {
+	setup()
+
 	header := &types.Header{Timestamp: 100000}
 
 	mockPriceFeed := new(MockPriceFeed)
@@ -700,6 +708,8 @@ func TestExecuteVote_PriceFeedError(t *testing.T) {
 }
 
 func TestExecuteVote_VoteError(t *testing.T) {
+	setup()
+
 	mockPriceFeed := new(MockPriceFeed)
 	mockTxRelayer := new(MockTxRelayer)
 	account := validator.NewTestValidator(t, "X", 1000).Account

--- a/price-oracle/state.go
+++ b/price-oracle/state.go
@@ -91,5 +91,10 @@ func (p priceOracleStateProvider) GetPriceOracleState(
 		return nil, err
 	}
 
-	return newPriceOracleState(p.blockchain.GetSystemState(provider), contracts.PriceOracleContract, provider, validatorAccount), nil
+	return newPriceOracleState(
+		p.blockchain.GetSystemState(provider),
+		contracts.PriceOracleContract,
+		provider,
+		validatorAccount,
+	), nil
 }

--- a/secrets/encryptedlocal/encryptedlocal.go
+++ b/secrets/encryptedlocal/encryptedlocal.go
@@ -51,6 +51,7 @@ func SecretsManagerFactory(
 
 func (esm *EncryptedLocalSecretsManager) SetSecret(name string, value []byte) error {
 	esm.logger.Info("Configuring secret", "name", name)
+
 	onSetHandler, ok := onSetHandlers[name]
 	if ok {
 		res, err := onSetHandler(esm, name, value)
@@ -101,8 +102,10 @@ func baseOnSetHandler(
 		name,
 		string(value),
 	)
+
 	confirmValue, err := esm.prompt.DefaultPrompt(
-		`Please re-type the secret key value (present above, after the "=") to confirm that you have backed it up in a safe location.`,
+		`Please re-type the secret key value (present above, after the "=") `+
+			`to confirm that you have backed it up in a safe location.`,
 		"",
 	)
 	if err != nil {
@@ -113,6 +116,7 @@ func baseOnSetHandler(
 		esm.logger.Error(
 			"The secret value you entered does not match the original value. Please try again.",
 		)
+
 		return nil, errors.New("secret value mismatch")
 	} else {
 		esm.logger.Info("The secret value you entered matches the original value. Continuing.")
@@ -146,6 +150,7 @@ func baseOnGetHandler(
 ) ([]byte, error) {
 	if esm.pwd == nil || len(esm.pwd) == 0 {
 		var err error
+
 		esm.pwd, err = esm.prompt.InputPassword(false)
 		if err != nil {
 			return nil, err

--- a/secrets/encryptedlocal/encryption.go
+++ b/secrets/encryptedlocal/encryption.go
@@ -54,6 +54,7 @@ func (ch *encryption) Encrypt(data []byte, pwd []byte) ([]byte, error) {
 
 func (ch *encryption) Decrypt(data []byte, pwd []byte) ([]byte, error) {
 	salt, data := data[len(data)-32:], data[:len(data)-32]
+
 	key, _, err := DeriveKey(pwd, salt)
 	if err != nil {
 		return nil, err
@@ -75,6 +76,7 @@ func (ch *encryption) Decrypt(data []byte, pwd []byte) ([]byte, error) {
 	}
 
 	nonce, ciphertext := data[:nonceSize], data[nonceSize:]
+
 	plaintext, err := gcm.Open(nil, nonce, ciphertext, nil)
 	if err != nil {
 		return nil, err

--- a/secrets/encryptedlocal/prompt.go
+++ b/secrets/encryptedlocal/prompt.go
@@ -15,10 +15,11 @@ import (
 
 var (
 	ErrInvalidPassword = errors.New(
-		"Password must contain at least one number, one uppercase letter, one special character, and be at least 8 characters long",
+		"password must contain at least one number, one uppercase letter, one special character, " +
+			"and be at least 8 characters long",
 	)
-	ErrPasswordMismatch    = errors.New("Passwords do not match")
-	ErrTerminatedOperation = errors.New("Operation terminated")
+	ErrPasswordMismatch    = errors.New("passwords do not match")
+	ErrTerminatedOperation = errors.New("operation terminated")
 )
 
 type Prompt struct {
@@ -50,6 +51,7 @@ func (p *Prompt) GenerateMnemonic(generator MnemonicGenerator) (string, error) {
 	fmt.Println("\nWe must generate a mnemonic which will represent your node account.")
 	fmt.Println("\nKeep it safe and do not share it with anyone.")
 	fmt.Println("\nYou will need this mnemonic to recover your node account if you lose it.")
+
 	start, err := p.DefaultPrompt("Do you want to start the process? [y/n]", "y")
 	if err != nil {
 		return "", err
@@ -61,8 +63,12 @@ func (p *Prompt) GenerateMnemonic(generator MnemonicGenerator) (string, error) {
 	}
 
 	mnemonic, err := generator.GenerateMnemonic()
+	if err != nil {
+		return "", err
+	}
 
 	fmt.Println("\nHere is your mnemonic. Please copy it and store it in a safe place.")
+
 	repeatMnemonic, err := p.DefaultPrompt(
 		"Please re-type the mnemonic to confirm that you have backed it up in a safe location.",
 		"",
@@ -73,10 +79,6 @@ func (p *Prompt) GenerateMnemonic(generator MnemonicGenerator) (string, error) {
 
 	if repeatMnemonic != mnemonic {
 		return "", errors.New("mnemonic mismatch")
-	}
-
-	if err != nil {
-		return "", err
 	}
 
 	return mnemonic, nil
@@ -91,6 +93,7 @@ func (p *Prompt) InputPassword(verify bool) ([]byte, error) {
 		}
 
 		fmt.Print("Enter password: ")
+
 		bytePassword, err := p.readPassword()
 		if err != nil {
 			return nil, err
@@ -108,6 +111,7 @@ func (p *Prompt) InputPassword(verify bool) ([]byte, error) {
 func (p *Prompt) ConfirmPassword(password []byte) (pass []byte, err error) {
 	return p.promptUntil(func() ([]byte, error) {
 		fmt.Print("\nConfirm password: ")
+
 		rePassword, err := p.readPassword()
 		if err != nil {
 			return nil, fmt.Errorf("error reading password: %w", err)
@@ -128,6 +132,7 @@ func (p *Prompt) readPassword() ([]byte, error) {
 // DefaultPrompt prompts the user for any text and performs no validation. If nothing is entered it returns the default.
 func (p *Prompt) DefaultPrompt(promptText, defaultValue string) (string, error) {
 	var response string
+
 	if defaultValue != "" {
 		fmt.Printf("%s %s:\n", promptText, fmt.Sprintf("(default: %s)", defaultValue))
 	} else {
@@ -137,10 +142,12 @@ func (p *Prompt) DefaultPrompt(promptText, defaultValue string) (string, error) 
 	scanner := bufio.NewScanner(os.Stdin)
 	if ok := scanner.Scan(); ok {
 		item := scanner.Text()
+
 		response = strings.TrimRight(item, "\r\n")
 		if response == "" {
 			return defaultValue, nil
 		}
+
 		return response, nil
 	}
 
@@ -175,6 +182,7 @@ func (p *Prompt) promptUntil(action func() (res []byte, err error)) (res []byte,
 		res, err := action()
 		if err != nil {
 			fmt.Printf("\n %s \n", err)
+
 			agree, err := p.tryAgain()
 			if err != nil {
 				return nil, err
@@ -205,6 +213,7 @@ func (p *Prompt) tryAgain() (agree bool, err error) {
 		return false, nil
 	default:
 		fmt.Println("Invalid input")
+
 		return p.tryAgain()
 	}
 }

--- a/secrets/secrets.go
+++ b/secrets/secrets.go
@@ -36,7 +36,7 @@ const (
 	ValidatorBLSSignature = "validator-bls-signature"
 
 	// CoinGeckoAPIKey is the API key for the coingecko endpoints
-	CoinGeckoAPIKey = "coingecko-api-key"
+	CoinGeckoAPIKey = "coingecko-api-key" //nolint:gosec
 )
 
 // Define constant file names for the local StorageManager

--- a/server/server.go
+++ b/server/server.go
@@ -196,6 +196,7 @@ func NewServer(config *Config) (*Server, error) {
 		if err != nil {
 			return nil, err
 		}
+
 		m.network = network
 	}
 
@@ -292,10 +293,10 @@ func NewServer(config *Config) (*Server, error) {
 
 	// Use the london signer with eip-155 as a fallback one
 	var signer crypto.TxSigner = crypto.NewLondonSigner(
-		uint64(m.config.Chain.Params.ChainID),
+		uint64(m.config.Chain.Params.ChainID), //nolint:gosec
 		config.Chain.Params.Forks.IsActive(chain.Homestead, 0),
 		crypto.NewEIP155Signer(
-			uint64(m.config.Chain.Params.ChainID),
+			uint64(m.config.Chain.Params.ChainID), //nolint:gosec
 			config.Chain.Params.Forks.IsActive(chain.Homestead, 0),
 		),
 	)
@@ -372,6 +373,7 @@ func NewServer(config *Config) (*Server, error) {
 		if err := m.setupConsensus(); err != nil {
 			return nil, err
 		}
+
 		m.blockchain.SetConsensus(m.consensus)
 	}
 
@@ -888,7 +890,7 @@ func (s *Server) setupJSONRPC() error {
 	conf := &jsonrpc.Config{
 		Store:                    hub,
 		Addr:                     s.config.JSONRPC.JSONRPCAddr,
-		ChainID:                  uint64(s.config.Chain.Params.ChainID),
+		ChainID:                  uint64(s.config.Chain.Params.ChainID), //nolint:gosec
 		ChainName:                s.chain.Name,
 		AccessControlAllowOrigin: s.config.JSONRPC.AccessControlAllowOrigin,
 		PriceLimit:               s.config.PriceLimit,

--- a/state/executor.go
+++ b/state/executor.go
@@ -83,7 +83,7 @@ func (e *Executor) WriteGenesis(
 		ctx:         env,
 		state:       txn,
 		auxState:    e.state,
-		gasPool:     uint64(env.GasLimit),
+		gasPool:     uint64(env.GasLimit), //nolint:gosec
 		config:      config,
 		precompiles: precompiled.NewPrecompiled(),
 	}
@@ -195,11 +195,11 @@ func (e *Executor) BeginTxn(
 
 	txCtx := runtime.TxContext{
 		Coinbase:     coinbaseReceiver,
-		Timestamp:    int64(header.Timestamp),
-		Number:       int64(header.Number),
+		Timestamp:    new(big.Int).SetUint64(header.Timestamp).Int64(),
+		Number:       new(big.Int).SetUint64(header.Number).Int64(),
 		Difficulty:   types.BytesToHash(new(big.Int).SetUint64(header.Difficulty).Bytes()),
 		BaseFee:      new(big.Int).SetUint64(header.BaseFee),
-		GasLimit:     int64(header.GasLimit),
+		GasLimit:     new(big.Int).SetUint64(header.GasLimit).Int64(),
 		ChainID:      e.config.ChainID,
 		BurnContract: burnContract,
 	}
@@ -212,7 +212,7 @@ func (e *Executor) BeginTxn(
 		getHash:  e.GetHash(header),
 		auxState: e.state,
 		config:   forkConfig,
-		gasPool:  uint64(txCtx.GasLimit),
+		gasPool:  uint64(txCtx.GasLimit), //nolint:gosec
 
 		receipts: []*types.Receipt{},
 		totalGas: 0,
@@ -341,7 +341,7 @@ func (t *Transition) Write(txn *types.Transaction) error {
 	if txn.From == emptyFrom &&
 		(txn.Type == types.LegacyTx || txn.Type == types.DynamicFeeTx) {
 		// Decrypt the from address
-		signer := crypto.NewSigner(t.config, uint64(t.ctx.ChainID))
+		signer := crypto.NewSigner(t.config, uint64(t.ctx.ChainID)) //nolint:gosec
 
 		txn.From, err = signer.Sender(txn)
 		if err != nil {
@@ -458,7 +458,7 @@ func (t *Transition) ContextPtr() *runtime.TxContext {
 
 func (t *Transition) subGasLimitPrice(msg *types.Transaction) error {
 	upfrontGasCost := GetLondonFixHandler(
-		uint64(t.ctx.Number),
+		uint64(t.ctx.Number), //nolint:gosec
 	).getUpfrontGasCost(msg, t.ctx.BaseFee)
 
 	if err := t.state.SubBalance(msg.From, upfrontGasCost); err != nil {
@@ -485,7 +485,7 @@ func (t *Transition) nonceCheck(msg *types.Transaction) error {
 // checkDynamicFees checks correctness of the EIP-1559 feature-related fields.
 // Basically, makes sure gas tip cap and gas fee cap are good for dynamic and legacy transactions
 func (t *Transition) checkDynamicFees(msg *types.Transaction) error {
-	return GetLondonFixHandler(uint64(t.ctx.Number)).checkDynamicFees(msg, t)
+	return GetLondonFixHandler(uint64(t.ctx.Number)).checkDynamicFees(msg, t) //nolint:gosec
 }
 
 // errors that can originate in the consensus rules checks of the apply method below
@@ -567,8 +567,10 @@ func (t *Transition) apply(msg *types.Transaction) (*runtime.ExecutionResult, er
 	// System transactions are verified at a higher level in fsm
 	// The above ensures fresh balance can be added only when consensus rules are met
 	areCoinsMinted := false
+
 	if msg.From == contracts.SystemCaller && msg.Value.Cmp(big.NewInt(0)) > 0 {
 		t.state.AddBalance(msg.From, msg.Value)
+
 		areCoinsMinted = true
 	}
 
@@ -608,10 +610,11 @@ func (t *Transition) apply(msg *types.Transaction) (*runtime.ExecutionResult, er
 		if err := t.state.IncrNonce(msg.From); err != nil {
 			return nil, err
 		}
+
 		result = t.Call2(msg.From, *msg.To, msg.Input, value, gasLeft)
 	}
 
-	// H: In case call is not successful and the amount is not transfered,
+	// H: In case call is not successful and the amount is not transferred,
 	// remove it from the system address
 	if areCoinsMinted && result != nil && result.Failed() {
 		err := t.state.SubBalance(msg.From, msg.Value)
@@ -635,7 +638,7 @@ func (t *Transition) apply(msg *types.Transaction) (*runtime.ExecutionResult, er
 	// Define effective tip based on tx type.
 	// We use EIP-1559 fields of the tx if the london hardfork is enabled.
 	// Effective tip became to be either gas tip cap or (gas fee cap - current base fee)
-	effectiveTip := GetLondonFixHandler(uint64(t.ctx.Number)).getEffectiveTip(
+	effectiveTip := GetLondonFixHandler(uint64(t.ctx.Number)).getEffectiveTip( //nolint:gosec
 		msg, gasPrice, t.ctx.BaseFee, t.config.London,
 	)
 
@@ -1003,7 +1006,7 @@ func (t *Transition) GetTxContext() runtime.TxContext {
 }
 
 func (t *Transition) GetBlockHash(number int64) (res types.Hash) {
-	return t.getHash(uint64(number))
+	return t.getHash(uint64(number)) //nolint:gosec
 }
 
 func (t *Transition) EmitLog(addr types.Address, topics []types.Hash, data []byte) {

--- a/state/txn.go
+++ b/state/txn.go
@@ -347,6 +347,7 @@ func (txn *Txn) IncrNonce(addr types.Address) error {
 
 			return
 		}
+
 		object.Account.Nonce++
 	})
 
@@ -430,6 +431,7 @@ func (txn *Txn) Suicide(addr types.Address) bool {
 			suicided = true
 			object.Suicide = true
 		}
+
 		if object != nil {
 			object.Account.Balance = new(big.Int)
 		}
@@ -520,7 +522,7 @@ func (txn *Txn) Empty(addr types.Address) bool {
 	return obj.Empty()
 }
 
-func newStateObject(txn *Txn) *StateObject {
+func newStateObject(_ *Txn) *StateObject {
 	return &StateObject{
 		Account: &Account{
 			Balance:  big.NewInt(0),
@@ -555,6 +557,7 @@ func (txn *Txn) CleanDeleteObjects(deleteEmptyObjects bool) error {
 		if !ok {
 			return false
 		}
+
 		if a.Suicide || a.Empty() && deleteEmptyObjects {
 			remove = append(remove, k)
 		}
@@ -612,20 +615,19 @@ func (txn *Txn) Commit(deleteEmptyObjects bool) ([]*Object, error) {
 		}
 		if a.Deleted {
 			obj.Deleted = true
-		} else {
-			if a.Txn != nil {
-				a.Txn.Root().Walk(func(k []byte, v interface{}) bool {
-					store := &StorageObject{Key: k}
-					if v == nil {
-						store.Deleted = true
-					} else {
-						store.Val = v.([]byte) //nolint:forcetypeassert
-					}
-					obj.Storage = append(obj.Storage, store)
+		} else if a.Txn != nil {
+			a.Txn.Root().Walk(func(k []byte, v interface{}) bool {
+				store := &StorageObject{Key: k}
+				if v == nil {
+					store.Deleted = true
+				} else {
+					store.Val = v.([]byte) //nolint:forcetypeassert
+				}
 
-					return false
-				})
-			}
+				obj.Storage = append(obj.Storage, store)
+
+				return false
+			})
 		}
 
 		objs = append(objs, obj)

--- a/syncer/client_test.go
+++ b/syncer/client_test.go
@@ -231,7 +231,6 @@ func TestStatusPubSub(t *testing.T) {
 }
 
 func TestPeerConnectionUpdateEventCh(t *testing.T) {
-	t.Skip()
 	t.Parallel()
 
 	var (
@@ -323,6 +322,7 @@ func TestPeerConnectionUpdateEventCh(t *testing.T) {
 	var (
 		wgForConnectingStatus sync.WaitGroup
 		newStatuses           []*NoForkPeer
+		statusCh              = client.GetPeerStatusUpdateCh()
 	)
 
 	wgForConnectingStatus.Add(1)
@@ -330,7 +330,7 @@ func TestPeerConnectionUpdateEventCh(t *testing.T) {
 	go func() {
 		defer wgForConnectingStatus.Done()
 
-		for status := range client.GetPeerStatusUpdateCh() {
+		for status := range statusCh {
 			newStatuses = append(newStatuses, status)
 		}
 	}()


### PR DESCRIPTION
# Description

- update go version to 1.21 and use `go mod tidy`;
- fix `golangci.yml` and some warnings related to property changes;
- add other paths for exclusion rules and make the line length 120 and add the output configuration;
- fix and add the lint, ci, build, and test workflows;
- fetch-depth is used to not doing a shallow checkout which avoids diff error for the linked revision;
- remove the sonar token to avoid the usage of the sonar's analyses;
- remove the race and shuffle flags from the make test command;
- optimize the `TestThrottling` test;
- set a separate `statusCh` variable to store the peer client and remove the `t.Skip()` from the `TestStatusPubSub` test;
- optimize the codebase based on the golintci issues;
- change `DefaultChainID` to `8844`;
- change error string to start with small letter in order to follow the golang conventions;
- actions/setup-go must be done after actions/setup-checkout for cache optimizations.
- updated the version of the actions;
- add submodules: recursive in the checkout action;

# Changes include

- [x] Bugfix (non-breaking change that solves an issue)
- [ ] Hotfix (change that solves an urgent issue, and requires immediate attention)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)

# Checklist

- [ ] I have assigned this PR to myself
- [x] I have added at least 1 reviewer
- [x] I have added the relevant labels
- [x] I have updated the official documentation
- [x] I have added sufficient documentation in code

## Testing

- [x] I have tested this code with the official test suite
- [ ] I have tested this code manually
