### PR TITLE
Fix val set size

### DIFF
--- a/command/genesis/genesis.go
+++ b/command/genesis/genesis.go
@@ -152,8 +152,9 @@ func setFlags(cmd *cobra.Command) {
 		cmd.Flags().Uint64Var(
 			&params.maxNumValidators,
 			command.MaxValidatorCountFlag,
-			common.MaxSafeJSInt,
-			"the maximum number of validators in the validator set for PoS",
+			150,
+			"the maximum number of validators in the validator set for PoS"+
+				"(This is the total maximum - the actual number is set in the core contracts)",
 		)
 
 		cmd.Flags().StringVar(


### PR DESCRIPTION
In the node, we have to set a limit on the validator set size that has more power than the rule set in the core-contracts.
It means that if the max validator set size is set to 50 in the contracts and 150 in the node, the actual validators will be up to 50.
If the max validator set size is set to 200 in the contracts and 150 in the node, the actual validators will be up to 150.

This PR just updates the default limit in the node.