### PR TITLE
fix(gasprice): prevent gas price oracle from ratcheting upward

### DIFF
--- a/gasprice/gasprice.go
+++ b/gasprice/gasprice.go
@@ -147,7 +147,6 @@ func (g *GasHelper) MaxPriorityFeePerGas() (*big.Int, error) {
 		blockMiner := types.BytesToAddress(block.Header.Miner)
 		signer := crypto.NewSigner(g.backend.Config().Forks.At(block.Number()),
 			uint64(g.backend.Config().ChainID))
-		blockTxPrices := make([]*big.Int, 0)
 
 		for _, tx := range txSorter.txs {
 			tip := tx.EffectiveGasTip(baseFee)
@@ -163,24 +162,20 @@ func (g *GasHelper) MaxPriorityFeePerGas() (*big.Int, error) {
 			}
 
 			if sender != blockMiner {
-				blockTxPrices = append(blockTxPrices, tip)
+				allPrices = append(allPrices, tip)
 
 				// if sample number of txs from block is reached,
 				// don't process any more txs
-				if len(blockTxPrices) >= int(g.sampleNumber) {
+				if len(allPrices) >= int(g.sampleNumber)*int(g.numOfBlocksToCheck) {
 					break
 				}
 			}
 		}
 
-		if len(blockTxPrices) == 0 {
-			// either block is empty or all transactions in block are sent by the miner.
-			// in this case add the latests calculated price for sampling
-			blockTxPrices = append(blockTxPrices, lastPrice)
-		}
-
-		// add the block prices to the slice of all prices
-		allPrices = append(allPrices, blockTxPrices...)
+		// Empty blocks are simply skipped — no synthetic lastPrice injection.
+		// On chains with sparse transactions (e.g. Hydra: ~700 txs/day, 0.4s blocks),
+		// injecting lastPrice into empty blocks causes a ratchet effect where the
+		// estimated gas price can only increase, never decrease.
 
 		return nil
 	}
@@ -198,16 +193,26 @@ func (g *GasHelper) MaxPriorityFeePerGas() (*big.Int, error) {
 		}
 	}
 
-	// at least amount of transactions to get
+	// If not enough transaction samples were collected from the initial window,
+	// scan further back to find more blocks with actual transactions.
 	minNumOfTx := int(g.numOfBlocksToCheck) * 2
-	// collect some more blocks and transactions if not enough transactions were collected
-	for len(allPrices) < minNumOfTx && currentBlock.Number() > 0 {
+	maxExtraBlocks := g.numOfBlocksToCheck * 5 // bounded scan to avoid traversing entire chain
+
+	for extraBlocks := uint64(0); len(allPrices) < minNumOfTx && currentBlock.Number() > 0 && extraBlocks < maxExtraBlocks; extraBlocks++ {
 		if err := collectPrices(currentBlock); err != nil {
 			return nil, err
 		}
+
+		currentBlock, found = g.backend.GetBlockByHash(currentBlock.ParentHash(), true)
+		if !found {
+			break
+		}
 	}
 
-	price := lastPrice
+	// If no real transactions were found in the scanned range, fall back to
+	// the initial default price (1 Gwei) rather than the previously cached price.
+	// This prevents the oracle from preserving a stale inflated estimate indefinitely.
+	price := new(big.Int).Set(DefaultGasHelperConfig.LastPrice)
 
 	if len(allPrices) > 0 {
 		// sort prices from lowest to highest

--- a/gasprice/gasprice.go
+++ b/gasprice/gasprice.go
@@ -73,6 +73,8 @@ type GasHelper struct {
 	maxPrice *big.Int
 	// lastPrice is the last price returned for maxPriorityFeePerGas
 	lastPrice *big.Int
+	// defaultPrice is the initial price from config, used as fallback when no txs found
+	defaultPrice *big.Int
 	// ignorePrice is the lowest price to take into consideration
 	// when collecting transactions
 	ignorePrice *big.Int
@@ -104,6 +106,7 @@ func NewGasHelper(config *Config, backend Blockchain) (*GasHelper, error) {
 		sampleNumber:       config.SampleNumber,
 		ignorePrice:        config.IgnorePrice,
 		lastPrice:          config.LastPrice,
+		defaultPrice:       new(big.Int).Set(config.LastPrice),
 		maxPrice:           config.MaxPrice,
 		backend:            backend,
 		historyCache:       cache,
@@ -148,6 +151,8 @@ func (g *GasHelper) MaxPriorityFeePerGas() (*big.Int, error) {
 		signer := crypto.NewSigner(g.backend.Config().Forks.At(block.Number()),
 			uint64(g.backend.Config().ChainID))
 
+		blockSamples := 0
+
 		for _, tx := range txSorter.txs {
 			tip := tx.EffectiveGasTip(baseFee)
 
@@ -163,10 +168,10 @@ func (g *GasHelper) MaxPriorityFeePerGas() (*big.Int, error) {
 
 			if sender != blockMiner {
 				allPrices = append(allPrices, tip)
+				blockSamples++
 
-				// if sample number of txs from block is reached,
-				// don't process any more txs
-				if len(allPrices) >= int(g.sampleNumber)*int(g.numOfBlocksToCheck) {
+				// cap samples per block to ensure diversity across blocks
+				if blockSamples >= int(g.sampleNumber) {
 					break
 				}
 			}
@@ -210,9 +215,9 @@ func (g *GasHelper) MaxPriorityFeePerGas() (*big.Int, error) {
 	}
 
 	// If no real transactions were found in the scanned range, fall back to
-	// the initial default price (1 Gwei) rather than the previously cached price.
-	// This prevents the oracle from preserving a stale inflated estimate indefinitely.
-	price := new(big.Int).Set(DefaultGasHelperConfig.LastPrice)
+	// the configured initial price (default: 1 Gwei) rather than the previously
+	// cached price. This prevents the oracle from preserving a stale inflated estimate.
+	price := new(big.Int).Set(g.defaultPrice)
 
 	if len(allPrices) > 0 {
 		// sort prices from lowest to highest

--- a/gasprice/gasprice_test.go
+++ b/gasprice/gasprice_test.go
@@ -194,7 +194,18 @@ func TestGasHelper_NoPriceRatchetOnEmptyBlocks(t *testing.T) {
 	require.NoError(t, err)
 	block25.Transactions = []*types.Transaction{highTipTx}
 
-	gasHelper, err := NewGasHelper(DefaultGasHelperConfig, backend)
+	// Use a local config to avoid the pre-existing data race where other parallel
+	// tests mutate DefaultGasHelperConfig.LastPrice in-place via big.Int.Mul()
+	testConfig := &Config{
+		NumOfBlocksToCheck: 20,
+		PricePercentile:    60,
+		SampleNumber:       3,
+		MaxPrice:           ethgo.Gwei(500),
+		LastPrice:          ethgo.Gwei(1),
+		IgnorePrice:        big.NewInt(2),
+	}
+
+	gasHelper, err := NewGasHelper(testConfig, backend)
 	require.NoError(t, err)
 
 	// First call — should pick up the high tip tx
@@ -234,7 +245,8 @@ func TestGasHelper_NoPriceRatchetOnEmptyBlocks(t *testing.T) {
 	// so price2 would equal price1. With the fix, it returns the default.
 	require.True(t, price2.Cmp(price1) < 0,
 		"gas price should decrease when recent blocks are empty, got price1=%s price2=%s", price1, price2)
-	require.Equal(t, DefaultGasHelperConfig.LastPrice, price2,
+	// Compare against a fresh value, not the global which other tests mutate in-place
+	require.Equal(t, ethgo.Gwei(1), price2,
 		"gas price should return to default when no recent transactions exist")
 }
 

--- a/gasprice/gasprice_test.go
+++ b/gasprice/gasprice_test.go
@@ -168,6 +168,76 @@ func TestGasHelper_MaxPriorityFeePerGas(t *testing.T) {
 	}
 }
 
+// TestGasHelper_NoPriceRatchetOnEmptyBlocks verifies that the gas price oracle
+// does not ratchet upward when most blocks are empty (sparse-transaction chains).
+// This was the root cause of gas price drift on Hydra mainnet.
+func TestGasHelper_NoPriceRatchetOnEmptyBlocks(t *testing.T) {
+	t.Parallel()
+
+	// Create 50 blocks, put 1 transaction with a high tip only in block 25
+	backend := createTestBlocks(t, 50)
+	senderKey, _ := tests.GenerateKeyAndAddr(t)
+
+	block25 := backend.blocksByNumber[25]
+	signer := crypto.NewSigner(backend.Config().Forks.At(block25.Number()),
+		uint64(backend.Config().ChainID))
+
+	highTipTx := &types.Transaction{
+		From:      types.ZeroAddress,
+		Value:     big.NewInt(0),
+		To:        &types.ZeroAddress,
+		Type:      types.DynamicFeeTx,
+		GasTipCap: ethgo.Gwei(100), // 100 Gwei tip - artificially high
+		GasFeeCap: ethgo.Gwei(200),
+	}
+	highTipTx, err := signer.SignTx(highTipTx, senderKey)
+	require.NoError(t, err)
+	block25.Transactions = []*types.Transaction{highTipTx}
+
+	gasHelper, err := NewGasHelper(DefaultGasHelperConfig, backend)
+	require.NoError(t, err)
+
+	// First call — should pick up the high tip tx
+	price1, err := gasHelper.MaxPriorityFeePerGas()
+	require.NoError(t, err)
+
+	// Now simulate time passing: update header to a new block with no txs
+	// The price should NOT keep the high value from the old tx
+	// Add enough empty blocks that the scan window (20 initial + 100 extended = 120)
+	// cannot reach block 25 with the high-tip tx
+	currentTop := backend.blocksByNumber[50]
+	for i := 51; i <= 200; i++ {
+		block := &types.Block{
+			Header: &types.Header{
+				Number:     uint64(i),
+				Hash:       types.BytesToHash([]byte(fmt.Sprintf("Block %d", i))),
+				Miner:      types.ZeroAddress.Bytes(),
+				ParentHash: currentTop.Hash(),
+				BaseFee:    chain.GenesisBaseFee,
+			},
+		}
+		backend.blocksByNumber[block.Number()] = block
+		backend.blocks[block.Hash()] = block
+		currentTop = block
+	}
+
+	// Reset mock to return new header
+	backend.ExpectedCalls = nil
+	backend.On("Header").Return(currentTop.Header)
+
+	// Second call — scanning the latest 20+100 blocks which are all empty
+	price2, err := gasHelper.MaxPriorityFeePerGas()
+	require.NoError(t, err)
+
+	// The price should fall back to the default (1 Gwei), not stay at 100 Gwei
+	// With the old buggy code, empty blocks injected lastPrice (100 Gwei),
+	// so price2 would equal price1. With the fix, it returns the default.
+	require.True(t, price2.Cmp(price1) < 0,
+		"gas price should decrease when recent blocks are empty, got price1=%s price2=%s", price1, price2)
+	require.Equal(t, DefaultGasHelperConfig.LastPrice, price2,
+		"gas price should return to default when no recent transactions exist")
+}
+
 func createTestBlocks(t *testing.T, numOfBlocks int) *backendMock {
 	t.Helper()
 


### PR DESCRIPTION
## Summary

- Fix gas price oracle feedback loop that caused `eth_gasPrice` to drift from 1 Gwei to 300+ Gwei on mainnet between daily node restarts
- Remove synthetic `lastPrice` injection into empty blocks that created a one-way ratchet
- Fix infinite-loop bug in the extended scan where `currentBlock` was never advanced
- Fall back to default 1 Gwei when no real transactions exist in the scan window

## Root Cause

On Hydra mainnet (~700 txs/day, ~216K blocks/day), 99.6% of blocks are empty. The oracle sampled 20 blocks, injecting `lastPrice` into every empty block. Any real tx with an above-baseline tip shifted the 60th percentile upward. That became the new `lastPrice`, which filled subsequent empty-block samples, creating an upward-only feedback loop.

## Validation

| Test | Result |
|------|--------|
| Unit tests (17 total, 1 new regression) | PASS |
| E2E devnet — buggy code | Gas price stayed at 50 Gwei after 34 empty blocks (ratchet confirmed) |
| E2E devnet — fixed code | Gas price recovered from 50 Gwei → 1 Gwei after 149 empty blocks (fix confirmed) |

## Deployment Plan

1. ~~Local devnet~~ (done)
2. Testnet — merge to `testnet`, build, deploy to testnet validator
3. Mainnet RPC nodes — build, deploy to RPC-1/2/3 (replaces cron restart workaround)
4. Mainnet validators — deploy to Validator-1/2

Closes #134

🤖 Generated with [Claude Code](https://claude.com/claude-code)