### PR TITLE
release: testnet → prod (trie pruning + gas price oracle fix)

### DIFF
--- a/command/prune/cmd.go
+++ b/command/prune/cmd.go
@@ -1,0 +1,23 @@
+package prune
+
+import (
+	"github.com/spf13/cobra"
+)
+
+func GetCommand() *cobra.Command {
+	pruneCmd := &cobra.Command{
+		Use:   "prune-trie",
+		Short: "Prunes historical state trie data by copying only reachable nodes to a new database",
+		Long: `Prunes the state trie LevelDB by copying only nodes reachable from the latest
+(or specified) block's state root to a new directory. The source trie is opened
+read-only and never modified. After validation, the operator can swap directories.
+
+Usage:
+  hydra prune-trie --data-dir ./node-secrets --target-path ./trie_new
+  hydra prune-trie --data-dir ./node-secrets --target-path ./trie_new --block 50000`,
+	}
+
+	pruneCmd.AddCommand(pruneTrieCmd())
+
+	return pruneCmd
+}

--- a/command/prune/get_state_root.go
+++ b/command/prune/get_state_root.go
@@ -1,0 +1,39 @@
+package prune
+
+import (
+	"fmt"
+
+	"github.com/0xPolygon/polygon-edge/blockchain/storage"
+	"github.com/0xPolygon/polygon-edge/types"
+)
+
+// GetLatestStateRoot reads the head block number from chain storage,
+// then returns the state root from that block's header.
+func GetLatestStateRoot(st storage.Storage) (types.Hash, uint64, error) {
+	headNum, ok := st.ReadHeadNumber()
+	if !ok {
+		return types.Hash{}, 0, fmt.Errorf("failed to read head number from chain storage")
+	}
+
+	root, err := GetStateRootAtBlock(st, headNum)
+	if err != nil {
+		return types.Hash{}, 0, fmt.Errorf("failed to get state root at head block %d: %w", headNum, err)
+	}
+
+	return root, headNum, nil
+}
+
+// GetStateRootAtBlock returns the state root from the header at a specific block number.
+func GetStateRootAtBlock(st storage.Storage, blockNum uint64) (types.Hash, error) {
+	canonicalHash, ok := st.ReadCanonicalHash(blockNum)
+	if !ok {
+		return types.Hash{}, fmt.Errorf("failed to read canonical hash for block %d", blockNum)
+	}
+
+	header, err := st.ReadHeader(canonicalHash)
+	if err != nil {
+		return types.Hash{}, fmt.Errorf("failed to read header for block %d (hash %s): %w", blockNum, canonicalHash, err)
+	}
+
+	return header.StateRoot, nil
+}

--- a/command/prune/get_state_root_test.go
+++ b/command/prune/get_state_root_test.go
@@ -1,0 +1,111 @@
+package prune
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/0xPolygon/polygon-edge/blockchain/storage"
+	"github.com/0xPolygon/polygon-edge/types"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestGetLatestStateRoot_ReturnsHeaderStateRoot(t *testing.T) {
+	t.Parallel()
+
+	expectedRoot := types.StringToHash("0xabcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890")
+	blockHash := types.StringToHash("0x1111111111111111111111111111111111111111111111111111111111111111")
+
+	mock := storage.NewMockStorage()
+	mock.HookReadHeadNumber(func() (uint64, bool) {
+		return 100, true
+	})
+	mock.HookReadCanonicalHash(func(n uint64) (types.Hash, bool) {
+		if n == 100 {
+			return blockHash, true
+		}
+
+		return types.Hash{}, false
+	})
+	mock.HookReadHeader(func(hash types.Hash) (*types.Header, error) {
+		if hash == blockHash {
+			return &types.Header{
+				Number:    100,
+				StateRoot: expectedRoot,
+			}, nil
+		}
+
+		return nil, errors.New("not found")
+	})
+
+	root, blockNum, err := GetLatestStateRoot(mock)
+	require.NoError(t, err)
+	assert.Equal(t, expectedRoot, root)
+	assert.Equal(t, uint64(100), blockNum)
+}
+
+func TestGetLatestStateRoot_EmptyChain(t *testing.T) {
+	t.Parallel()
+
+	mock := storage.NewMockStorage()
+	mock.HookReadHeadNumber(func() (uint64, bool) {
+		return 0, false
+	})
+
+	_, _, err := GetLatestStateRoot(mock)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "head")
+}
+
+func TestGetStateRootAtBlock_ReturnsCorrectRoot(t *testing.T) {
+	t.Parallel()
+
+	roots := map[uint64]types.Hash{
+		5:  types.StringToHash("0x5555555555555555555555555555555555555555555555555555555555555555"),
+		10: types.StringToHash("0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"),
+	}
+
+	hashes := map[uint64]types.Hash{
+		5:  types.StringToHash("0x0505050505050505050505050505050505050505050505050505050505050505"),
+		10: types.StringToHash("0x0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a"),
+	}
+
+	mock := storage.NewMockStorage()
+	mock.HookReadCanonicalHash(func(n uint64) (types.Hash, bool) {
+		h, ok := hashes[n]
+		return h, ok
+	})
+	mock.HookReadHeader(func(hash types.Hash) (*types.Header, error) {
+		for num, h := range hashes {
+			if h == hash {
+				return &types.Header{
+					Number:    num,
+					StateRoot: roots[num],
+				}, nil
+			}
+		}
+
+		return nil, errors.New("not found")
+	})
+
+	root, err := GetStateRootAtBlock(mock, 5)
+	require.NoError(t, err)
+	assert.Equal(t, roots[5], root)
+
+	root, err = GetStateRootAtBlock(mock, 10)
+	require.NoError(t, err)
+	assert.Equal(t, roots[10], root)
+}
+
+func TestGetStateRootAtBlock_NonexistentBlock(t *testing.T) {
+	t.Parallel()
+
+	mock := storage.NewMockStorage()
+	mock.HookReadCanonicalHash(func(n uint64) (types.Hash, bool) {
+		return types.Hash{}, false
+	})
+
+	_, err := GetStateRootAtBlock(mock, 999)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "canonical hash")
+}

--- a/command/prune/get_state_root_test.go
+++ b/command/prune/get_state_root_test.go
@@ -73,6 +73,7 @@ func TestGetStateRootAtBlock_ReturnsCorrectRoot(t *testing.T) {
 	mock := storage.NewMockStorage()
 	mock.HookReadCanonicalHash(func(n uint64) (types.Hash, bool) {
 		h, ok := hashes[n]
+
 		return h, ok
 	})
 	mock.HookReadHeader(func(hash types.Hash) (*types.Header, error) {

--- a/command/prune/integration_test.go
+++ b/command/prune/integration_test.go
@@ -1,0 +1,304 @@
+package prune
+
+import (
+	"math/big"
+	"os"
+	"path/filepath"
+	"testing"
+
+	chainstorage "github.com/0xPolygon/polygon-edge/blockchain/storage"
+	ldbchain "github.com/0xPolygon/polygon-edge/blockchain/storage/leveldb"
+	"github.com/0xPolygon/polygon-edge/state"
+	itrie "github.com/0xPolygon/polygon-edge/state/immutable-trie"
+	"github.com/0xPolygon/polygon-edge/types"
+	hclog "github.com/hashicorp/go-hclog"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/syndtr/goleveldb/leveldb"
+	"github.com/syndtr/goleveldb/leveldb/opt"
+)
+
+func TestIntegration_FullPipeline(t *testing.T) {
+	// Create temp directories
+	baseDir, err := os.MkdirTemp("", "prune_integration")
+	require.NoError(t, err)
+
+	defer os.RemoveAll(baseDir)
+
+	dataDir := filepath.Join(baseDir, "node-data")
+	triePath := filepath.Join(dataDir, "trie")
+	blockchainPath := filepath.Join(dataDir, "blockchain")
+	targetPath := filepath.Join(baseDir, "trie_new")
+
+	require.NoError(t, os.MkdirAll(triePath, 0755))
+	require.NoError(t, os.MkdirAll(blockchainPath, 0755))
+
+	// Create trie storage and state
+	trieStorage, err := itrie.NewLevelDBStorage(triePath, hclog.NewNullLogger())
+	require.NoError(t, err)
+
+	st := itrie.NewState(trieStorage)
+
+	// Create chain storage
+	chainStorage, err := ldbchain.NewLevelDBStorage(blockchainPath, hclog.NewNullLogger())
+	require.NoError(t, err)
+
+	// Simulate multiple blocks with account state changes
+	accounts := []types.Address{
+		{0x01}, {0x02}, {0x03}, {0x04}, {0x05},
+	}
+
+	snap := st.NewSnapshot()
+	var lastRoot []byte
+
+	for block := uint64(1); block <= 5; block++ {
+		objs := make([]*state.Object, len(accounts))
+		for i, addr := range accounts {
+			objs[i] = &state.Object{
+				Address:  addr,
+				CodeHash: types.EmptyCodeHash,
+				Balance:  big.NewInt(int64(1000*block) + int64(i)),
+				Root:     types.EmptyRootHash,
+				Nonce:    block,
+			}
+		}
+
+		var root []byte
+		snap, root, err = snap.Commit(objs)
+		require.NoError(t, err)
+		require.NotNil(t, root)
+
+		lastRoot = root
+
+		// Write block header to chain storage
+		header := &types.Header{
+			Number:    block,
+			StateRoot: types.BytesToHash(root),
+			Hash:      types.BytesToHash([]byte{byte(block), 0xAA}), // deterministic hash
+		}
+
+		bw := chainstorage.NewBatchWriter(chainStorage)
+		bw.PutCanonicalHeader(header, big.NewInt(int64(block)))
+		require.NoError(t, bw.WriteBatch())
+	}
+
+	// Close storages before pruning (prune opens read-only)
+	trieStorage.Close()
+	chainStorage.Close()
+
+	// Verify source has accumulated keys from all 5 blocks
+	srcDB, err := leveldb.OpenFile(triePath, &opt.Options{ReadOnly: true})
+	require.NoError(t, err)
+
+	srcKeys, err := itrie.KeyCount(srcDB)
+	require.NoError(t, err)
+
+	srcDB.Close()
+
+	require.Greater(t, srcKeys, int64(0), "source should have trie nodes")
+
+	// Run prune via the programmatic interface
+	srcDB, err = leveldb.OpenFile(triePath, &opt.Options{ReadOnly: true})
+	require.NoError(t, err)
+
+	dstDB, err := leveldb.OpenFile(targetPath, nil)
+	require.NoError(t, err)
+
+	result, err := itrie.PruneTrie(types.BytesToHash(lastRoot), srcDB, dstDB)
+	require.NoError(t, err)
+	require.True(t, result.Validated)
+	assert.Less(t, result.DestKeys, srcKeys, "pruned trie should have fewer keys")
+	assert.Greater(t, result.DestKeys, int64(0), "pruned trie should not be empty")
+
+	srcDB.Close()
+	dstDB.Close()
+
+	// Verify: create state from pruned trie, read accounts
+	prunedStorage, err := itrie.NewLevelDBStorage(targetPath, hclog.NewNullLogger())
+	require.NoError(t, err)
+
+	defer prunedStorage.Close()
+
+	prunedState := itrie.NewState(prunedStorage)
+
+	prunedSnap, err := prunedState.NewSnapshotAt(types.BytesToHash(lastRoot))
+	require.NoError(t, err)
+
+	// Verify all accounts from block 5 are readable
+	for i, addr := range accounts {
+		account, err := prunedSnap.GetAccount(addr)
+		require.NoError(t, err, "account %s should be readable from pruned trie", addr)
+		require.NotNil(t, account, "account %s should exist", addr)
+
+		expectedBalance := big.NewInt(int64(1000*5) + int64(i))
+		assert.Equal(t, expectedBalance, account.Balance, "account %s balance mismatch", addr)
+		assert.Equal(t, uint64(5), account.Nonce, "account %s nonce mismatch", addr)
+	}
+
+	// Verify state root resolution works via our helper
+	chainStorage2, err := ldbchain.NewLevelDBStorage(blockchainPath, hclog.NewNullLogger())
+	require.NoError(t, err)
+
+	defer chainStorage2.Close()
+
+	resolvedRoot, resolvedBlock, err := GetLatestStateRoot(chainStorage2)
+	require.NoError(t, err)
+	assert.Equal(t, types.BytesToHash(lastRoot), resolvedRoot)
+	assert.Equal(t, uint64(5), resolvedBlock)
+}
+
+func TestIntegration_SpecificBlock(t *testing.T) {
+	baseDir, err := os.MkdirTemp("", "prune_specific_block")
+	require.NoError(t, err)
+
+	defer os.RemoveAll(baseDir)
+
+	dataDir := filepath.Join(baseDir, "node-data")
+	triePath := filepath.Join(dataDir, "trie")
+	blockchainPath := filepath.Join(dataDir, "blockchain")
+	targetPath := filepath.Join(baseDir, "trie_new")
+
+	require.NoError(t, os.MkdirAll(triePath, 0755))
+	require.NoError(t, os.MkdirAll(blockchainPath, 0755))
+
+	trieStorage, err := itrie.NewLevelDBStorage(triePath, hclog.NewNullLogger())
+	require.NoError(t, err)
+
+	st := itrie.NewState(trieStorage)
+	chainStorage, err := ldbchain.NewLevelDBStorage(blockchainPath, hclog.NewNullLogger())
+	require.NoError(t, err)
+
+	snap := st.NewSnapshot()
+	roots := make(map[uint64]types.Hash)
+
+	for block := uint64(1); block <= 3; block++ {
+		objs := []*state.Object{{
+			Address:  types.Address{byte(block)},
+			CodeHash: types.EmptyCodeHash,
+			Balance:  big.NewInt(int64(block * 100)),
+			Root:     types.EmptyRootHash,
+			Nonce:    block,
+		}}
+
+		var root []byte
+		snap, root, err = snap.Commit(objs)
+		require.NoError(t, err)
+
+		roots[block] = types.BytesToHash(root)
+
+		header := &types.Header{
+			Number:    block,
+			StateRoot: types.BytesToHash(root),
+			Hash:      types.BytesToHash([]byte{byte(block), 0xBB}),
+		}
+
+		bw := chainstorage.NewBatchWriter(chainStorage)
+		bw.PutCanonicalHeader(header, big.NewInt(int64(block)))
+		require.NoError(t, bw.WriteBatch())
+	}
+
+	trieStorage.Close()
+	chainStorage.Close()
+
+	// Prune at block 2 (not latest)
+	srcDB, err := leveldb.OpenFile(triePath, &opt.Options{ReadOnly: true})
+	require.NoError(t, err)
+
+	dstDB, err := leveldb.OpenFile(targetPath, nil)
+	require.NoError(t, err)
+
+	result, err := itrie.PruneTrie(roots[2], srcDB, dstDB)
+	require.NoError(t, err)
+	require.True(t, result.Validated)
+
+	srcDB.Close()
+	dstDB.Close()
+
+	// Verify block 2's state is accessible
+	prunedStorage, err := itrie.NewLevelDBStorage(targetPath, hclog.NewNullLogger())
+	require.NoError(t, err)
+
+	defer prunedStorage.Close()
+
+	prunedState := itrie.NewState(prunedStorage)
+	prunedSnap, err := prunedState.NewSnapshotAt(roots[2])
+	require.NoError(t, err)
+
+	// Account from block 2 should exist
+	account, err := prunedSnap.GetAccount(types.Address{0x02})
+	require.NoError(t, err)
+	require.NotNil(t, account)
+	assert.Equal(t, big.NewInt(200), account.Balance)
+}
+
+func TestIntegration_SourceUnchanged(t *testing.T) {
+	baseDir, err := os.MkdirTemp("", "prune_source_intact")
+	require.NoError(t, err)
+
+	defer os.RemoveAll(baseDir)
+
+	triePath := filepath.Join(baseDir, "trie")
+	targetPath := filepath.Join(baseDir, "trie_new")
+
+	trieStorage, err := itrie.NewLevelDBStorage(triePath, hclog.NewNullLogger())
+	require.NoError(t, err)
+
+	st := itrie.NewState(trieStorage)
+	snap := st.NewSnapshot()
+
+	objs := []*state.Object{{
+		Address:  types.Address{0x01},
+		CodeHash: types.EmptyCodeHash,
+		Balance:  big.NewInt(42),
+		Root:     types.EmptyRootHash,
+		Nonce:    1,
+	}}
+
+	_, root, err := snap.Commit(objs)
+	require.NoError(t, err)
+
+	trieStorage.Close()
+
+	// Count source keys before prune
+	srcDB, err := leveldb.OpenFile(triePath, &opt.Options{ReadOnly: true})
+	require.NoError(t, err)
+
+	keysBefore, err := itrie.KeyCount(srcDB)
+	require.NoError(t, err)
+
+	srcDB.Close()
+
+	// Run prune
+	srcDB, err = leveldb.OpenFile(triePath, &opt.Options{ReadOnly: true})
+	require.NoError(t, err)
+
+	dstDB, err := leveldb.OpenFile(targetPath, nil)
+	require.NoError(t, err)
+
+	_, err = itrie.PruneTrie(types.BytesToHash(root), srcDB, dstDB)
+	require.NoError(t, err)
+
+	srcDB.Close()
+	dstDB.Close()
+
+	// Verify source unchanged
+	srcDB, err = leveldb.OpenFile(triePath, &opt.Options{ReadOnly: true})
+	require.NoError(t, err)
+
+	keysAfter, err := itrie.KeyCount(srcDB)
+	require.NoError(t, err)
+
+	srcDB.Close()
+
+	assert.Equal(t, keysBefore, keysAfter, "source should have identical key count after prune")
+
+	// Verify source state root still valid
+	srcStorage, err := itrie.NewLevelDBStorage(triePath, hclog.NewNullLogger())
+	require.NoError(t, err)
+
+	defer srcStorage.Close()
+
+	checkedRoot, err := itrie.HashChecker(root, srcStorage)
+	require.NoError(t, err)
+	assert.Equal(t, types.BytesToHash(root), checkedRoot, "source state root should be unchanged")
+}

--- a/command/prune/prune.go
+++ b/command/prune/prune.go
@@ -6,8 +6,8 @@ import (
 	"os"
 	"path/filepath"
 
-	"github.com/0xPolygon/polygon-edge/command"
 	leveldb2 "github.com/0xPolygon/polygon-edge/blockchain/storage/leveldb"
+	"github.com/0xPolygon/polygon-edge/command"
 	itrie "github.com/0xPolygon/polygon-edge/state/immutable-trie"
 	"github.com/0xPolygon/polygon-edge/types"
 	hclog "github.com/hashicorp/go-hclog"
@@ -30,7 +30,10 @@ func pruneTrieCmd() *cobra.Command {
 		Short: "Run the trie pruning operation",
 	}
 
-	cmd.Flags().StringVar(&params.DataDir, "data-dir", "", "path to node data directory (contains trie/ and blockchain/ subdirs)")
+	cmd.Flags().StringVar(
+		&params.DataDir, "data-dir", "",
+		"path to node data directory (contains trie/ and blockchain/ subdirs)",
+	)
 	cmd.Flags().StringVar(&params.TargetPath, "target-path", "", "path for the new pruned trie database")
 	cmd.Flags().Uint64Var(&params.BlockNum, "block", 0, "block number to prune at (default: latest)")
 
@@ -41,12 +44,14 @@ func pruneTrieCmd() *cobra.Command {
 
 		if err := validateParams(); err != nil {
 			outputter.SetError(err)
+
 			return
 		}
 
 		result, err := runPrune()
 		if err != nil {
 			outputter.SetError(err)
+
 			return
 		}
 
@@ -106,14 +111,17 @@ func runPrune() (*PruneTrieResult, error) {
 	defer chainStorage.Close()
 
 	// Resolve state root
-	var stateRoot types.Hash
-	var blockNum uint64
+	var (
+		stateRoot types.Hash
+		blockNum  uint64
+	)
 
 	if params.BlockNum > 0 {
 		stateRoot, err = GetStateRootAtBlock(chainStorage, params.BlockNum)
 		if err != nil {
 			return nil, err
 		}
+
 		blockNum = params.BlockNum
 	} else {
 		stateRoot, blockNum, err = GetLatestStateRoot(chainStorage)

--- a/command/prune/prune.go
+++ b/command/prune/prune.go
@@ -1,0 +1,222 @@
+package prune
+
+import (
+	"bytes"
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/0xPolygon/polygon-edge/command"
+	leveldb2 "github.com/0xPolygon/polygon-edge/blockchain/storage/leveldb"
+	itrie "github.com/0xPolygon/polygon-edge/state/immutable-trie"
+	"github.com/0xPolygon/polygon-edge/types"
+	hclog "github.com/hashicorp/go-hclog"
+	"github.com/spf13/cobra"
+	"github.com/syndtr/goleveldb/leveldb"
+	"github.com/syndtr/goleveldb/leveldb/opt"
+)
+
+type pruneParams struct {
+	DataDir    string
+	TargetPath string
+	BlockNum   uint64
+}
+
+var params pruneParams
+
+func pruneTrieCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "run",
+		Short: "Run the trie pruning operation",
+	}
+
+	cmd.Flags().StringVar(&params.DataDir, "data-dir", "", "path to node data directory (contains trie/ and blockchain/ subdirs)")
+	cmd.Flags().StringVar(&params.TargetPath, "target-path", "", "path for the new pruned trie database")
+	cmd.Flags().Uint64Var(&params.BlockNum, "block", 0, "block number to prune at (default: latest)")
+
+	outputter := command.InitializeOutputter(cmd)
+
+	cmd.Run = func(cmd *cobra.Command, args []string) {
+		defer outputter.WriteOutput()
+
+		if err := validateParams(); err != nil {
+			outputter.SetError(err)
+			return
+		}
+
+		result, err := runPrune()
+		if err != nil {
+			outputter.SetError(err)
+			return
+		}
+
+		outputter.WriteCommandResult(result)
+	}
+
+	return cmd
+}
+
+func validateParams() error {
+	if params.DataDir == "" {
+		return fmt.Errorf("--data-dir is required")
+	}
+
+	if params.TargetPath == "" {
+		return fmt.Errorf("--target-path is required")
+	}
+
+	triePath := filepath.Join(params.DataDir, "trie")
+	if _, err := os.Stat(triePath); os.IsNotExist(err) {
+		return fmt.Errorf("trie directory not found at %s", triePath)
+	}
+
+	blockchainPath := filepath.Join(params.DataDir, "blockchain")
+	if _, err := os.Stat(blockchainPath); os.IsNotExist(err) {
+		return fmt.Errorf("blockchain directory not found at %s", blockchainPath)
+	}
+
+	// Ensure target doesn't already have data
+	if info, err := os.Stat(params.TargetPath); err == nil && info.IsDir() {
+		entries, err := os.ReadDir(params.TargetPath)
+		if err == nil && len(entries) > 0 {
+			return fmt.Errorf("target path %s already exists and is not empty", params.TargetPath)
+		}
+	}
+
+	// Ensure target is not the same as source trie
+	absTarget, _ := filepath.Abs(params.TargetPath)
+	absSource, _ := filepath.Abs(filepath.Join(params.DataDir, "trie"))
+
+	if absTarget == absSource {
+		return fmt.Errorf("target path cannot be the same as source trie path")
+	}
+
+	return nil
+}
+
+func runPrune() (*PruneTrieResult, error) {
+	triePath := filepath.Join(params.DataDir, "trie")
+	blockchainPath := filepath.Join(params.DataDir, "blockchain")
+
+	// Open blockchain storage to resolve state root
+	chainStorage, err := leveldb2.NewLevelDBStorage(blockchainPath, hclog.NewNullLogger())
+	if err != nil {
+		return nil, fmt.Errorf("failed to open blockchain storage: %w", err)
+	}
+	defer chainStorage.Close()
+
+	// Resolve state root
+	var stateRoot types.Hash
+	var blockNum uint64
+
+	if params.BlockNum > 0 {
+		stateRoot, err = GetStateRootAtBlock(chainStorage, params.BlockNum)
+		if err != nil {
+			return nil, err
+		}
+		blockNum = params.BlockNum
+	} else {
+		stateRoot, blockNum, err = GetLatestStateRoot(chainStorage)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	// Open source trie read-only
+	srcDB, err := leveldb.OpenFile(triePath, &opt.Options{ReadOnly: true})
+	if err != nil {
+		return nil, fmt.Errorf("failed to open source trie (read-only): %w", err)
+	}
+	defer srcDB.Close()
+
+	// Open target trie for writing
+	dstDB, err := leveldb.OpenFile(params.TargetPath, nil)
+	if err != nil {
+		return nil, fmt.Errorf("failed to open target trie: %w", err)
+	}
+	defer dstDB.Close()
+
+	// Get source size before pruning
+	srcSize, _ := itrie.DiskSizeBytes(triePath)
+
+	// Run prune
+	result, err := itrie.PruneTrie(stateRoot, srcDB, dstDB)
+	if err != nil {
+		return nil, fmt.Errorf("prune failed: %w", err)
+	}
+
+	result.BlockNum = blockNum
+
+	// Get dest size after pruning
+	dstSize, _ := itrie.DiskSizeBytes(params.TargetPath)
+	result.SourceSize = srcSize
+	result.DestSize = dstSize
+
+	return &PruneTrieResult{
+		BlockNum:   blockNum,
+		StateRoot:  stateRoot.String(),
+		SourceKeys: result.SourceKeys,
+		DestKeys:   result.DestKeys,
+		SourceSize: srcSize,
+		DestSize:   dstSize,
+		Duration:   result.Duration.String(),
+		Validated:  result.Validated,
+	}, nil
+}
+
+// PruneTrieResult is the CLI output format
+type PruneTrieResult struct {
+	BlockNum   uint64 `json:"block_number"`
+	StateRoot  string `json:"state_root"`
+	SourceKeys int64  `json:"source_keys"`
+	DestKeys   int64  `json:"dest_keys"`
+	SourceSize int64  `json:"source_size_bytes"`
+	DestSize   int64  `json:"dest_size_bytes"`
+	Duration   string `json:"duration"`
+	Validated  bool   `json:"validated"`
+}
+
+func (r *PruneTrieResult) GetOutput() string {
+	var buffer bytes.Buffer
+
+	buffer.WriteString("\n[TRIE PRUNE RESULT]\n")
+	buffer.WriteString(fmt.Sprintf("Block:        %d\n", r.BlockNum))
+	buffer.WriteString(fmt.Sprintf("State Root:   %s\n", r.StateRoot))
+	buffer.WriteString(fmt.Sprintf("Source Keys:  %d\n", r.SourceKeys))
+	buffer.WriteString(fmt.Sprintf("Dest Keys:    %d\n", r.DestKeys))
+	buffer.WriteString(fmt.Sprintf("Source Size:  %s\n", formatBytes(r.SourceSize)))
+	buffer.WriteString(fmt.Sprintf("Dest Size:    %s\n", formatBytes(r.DestSize)))
+
+	if r.SourceSize > 0 {
+		reduction := float64(r.SourceSize-r.DestSize) / float64(r.SourceSize) * 100
+		buffer.WriteString(fmt.Sprintf("Reduction:    %.1f%%\n", reduction))
+	}
+
+	buffer.WriteString(fmt.Sprintf("Duration:     %s\n", r.Duration))
+	buffer.WriteString(fmt.Sprintf("Validated:    %v\n", r.Validated))
+
+	if r.Validated {
+		buffer.WriteString("\nState root verified. You can now swap directories:\n")
+		buffer.WriteString("  mv <data-dir>/trie <data-dir>/trie_old\n")
+		buffer.WriteString("  mv <target-path> <data-dir>/trie\n")
+	}
+
+	return buffer.String()
+}
+
+func formatBytes(b int64) string {
+	const unit = 1024
+
+	if b < unit {
+		return fmt.Sprintf("%d B", b)
+	}
+
+	div, exp := int64(unit), 0
+
+	for n := b / unit; n >= unit; n /= unit {
+		div *= unit
+		exp++
+	}
+
+	return fmt.Sprintf("%.1f %cB", float64(b)/float64(div), "KMGTPE"[exp])
+}

--- a/command/prune/validate_test.go
+++ b/command/prune/validate_test.go
@@ -1,0 +1,140 @@
+package prune
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func setupTestDataDir(t *testing.T) string {
+	t.Helper()
+
+	dir, err := os.MkdirTemp("", "prune_validate_test")
+	require.NoError(t, err)
+
+	t.Cleanup(func() { os.RemoveAll(dir) })
+
+	// Create trie/ and blockchain/ subdirs
+	require.NoError(t, os.MkdirAll(filepath.Join(dir, "trie"), 0755))
+	require.NoError(t, os.MkdirAll(filepath.Join(dir, "blockchain"), 0755))
+
+	return dir
+}
+
+func TestValidateParams_MissingDataDir(t *testing.T) {
+	params = pruneParams{
+		DataDir:    "",
+		TargetPath: "/tmp/target",
+	}
+
+	err := validateParams()
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "--data-dir")
+}
+
+func TestValidateParams_MissingTargetPath(t *testing.T) {
+	params = pruneParams{
+		DataDir:    "/tmp/some-dir",
+		TargetPath: "",
+	}
+
+	err := validateParams()
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "--target-path")
+}
+
+func TestValidateParams_NonexistentDataDir(t *testing.T) {
+	params = pruneParams{
+		DataDir:    "/nonexistent/path/xyz123",
+		TargetPath: "/tmp/target",
+	}
+
+	err := validateParams()
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "trie directory not found")
+}
+
+func TestValidateParams_MissingTrieSubdir(t *testing.T) {
+	dir, err := os.MkdirTemp("", "prune_no_trie")
+	require.NoError(t, err)
+
+	defer os.RemoveAll(dir)
+
+	require.NoError(t, os.MkdirAll(filepath.Join(dir, "blockchain"), 0755))
+
+	params = pruneParams{
+		DataDir:    dir,
+		TargetPath: "/tmp/target",
+	}
+
+	err = validateParams()
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "trie directory not found")
+}
+
+func TestValidateParams_MissingBlockchainSubdir(t *testing.T) {
+	dir, err := os.MkdirTemp("", "prune_no_blockchain")
+	require.NoError(t, err)
+
+	defer os.RemoveAll(dir)
+
+	require.NoError(t, os.MkdirAll(filepath.Join(dir, "trie"), 0755))
+
+	params = pruneParams{
+		DataDir:    dir,
+		TargetPath: "/tmp/target",
+	}
+
+	err = validateParams()
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "blockchain directory not found")
+}
+
+func TestValidateParams_TargetEqualsSource(t *testing.T) {
+	dir := setupTestDataDir(t)
+
+	params = pruneParams{
+		DataDir:    dir,
+		TargetPath: filepath.Join(dir, "trie"),
+	}
+
+	err := validateParams()
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "cannot be the same")
+}
+
+func TestValidateParams_TargetNonEmpty(t *testing.T) {
+	dir := setupTestDataDir(t)
+
+	targetDir, err := os.MkdirTemp("", "prune_nonempty_target")
+	require.NoError(t, err)
+
+	defer os.RemoveAll(targetDir)
+
+	// Put a file in target to make it non-empty
+	require.NoError(t, os.WriteFile(filepath.Join(targetDir, "dummy"), []byte("data"), 0644))
+
+	params = pruneParams{
+		DataDir:    dir,
+		TargetPath: targetDir,
+	}
+
+	err = validateParams()
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "not empty")
+}
+
+func TestValidateParams_ValidParams(t *testing.T) {
+	dir := setupTestDataDir(t)
+
+	params = pruneParams{
+		DataDir:    dir,
+		TargetPath: filepath.Join(dir, "trie_new"),
+	}
+
+	err := validateParams()
+	assert.NoError(t, err)
+}

--- a/command/root/root.go
+++ b/command/root/root.go
@@ -14,6 +14,7 @@ import (
 	"github.com/0xPolygon/polygon-edge/command/monitor"
 	"github.com/0xPolygon/polygon-edge/command/peers"
 	"github.com/0xPolygon/polygon-edge/command/polybft"
+	"github.com/0xPolygon/polygon-edge/command/prune"
 	"github.com/0xPolygon/polygon-edge/command/regenesis"
 	"github.com/0xPolygon/polygon-edge/command/secrets"
 	"github.com/0xPolygon/polygon-edge/command/server"
@@ -56,6 +57,7 @@ func (rc *RootCommand) registerSubCommands() {
 		polybft.GetCommand(),
 		bridge.GetCommand(),
 		regenesis.GetCommand(),
+		prune.GetCommand(),
 	)
 }
 

--- a/command/server/params.go
+++ b/command/server/params.go
@@ -101,7 +101,7 @@ type serverParams struct {
 
 	logFileLocation string
 
-	relayer    bool
+	relayer     bool
 	shouldPrune bool
 }
 

--- a/command/server/params.go
+++ b/command/server/params.go
@@ -48,6 +48,7 @@ const (
 	webSocketReadLimitFlag      = "websocket-read-limit"
 
 	metricsIntervalFlag = "metrics-interval"
+	pruneFlag           = "prune"
 )
 
 // Flags that are deprecated, but need to be preserved for
@@ -100,7 +101,8 @@ type serverParams struct {
 
 	logFileLocation string
 
-	relayer bool
+	relayer    bool
+	shouldPrune bool
 }
 
 func (p *serverParams) isMaxPeersSet() bool {

--- a/command/server/server.go
+++ b/command/server/server.go
@@ -3,12 +3,22 @@ package server
 import (
 	"fmt"
 
+	"os"
+	"path/filepath"
+
 	"github.com/0xPolygon/polygon-edge/command"
 	"github.com/0xPolygon/polygon-edge/command/helper"
 	"github.com/0xPolygon/polygon-edge/command/server/config"
 	"github.com/0xPolygon/polygon-edge/command/server/export"
 	"github.com/0xPolygon/polygon-edge/server"
 	"github.com/spf13/cobra"
+
+	leveldb2 "github.com/0xPolygon/polygon-edge/blockchain/storage/leveldb"
+	pruneCmd "github.com/0xPolygon/polygon-edge/command/prune"
+	itrie "github.com/0xPolygon/polygon-edge/state/immutable-trie"
+	hclog "github.com/hashicorp/go-hclog"
+	"github.com/syndtr/goleveldb/leveldb"
+	"github.com/syndtr/goleveldb/leveldb/opt"
 )
 
 func GetCommand() *cobra.Command {
@@ -254,6 +264,15 @@ func setFlags(cmd *cobra.Command) {
 		"the interval (in seconds) at which special metrics are generated. a value of zero means the metrics are disabled",
 	)
 
+	cmd.Flags().BoolVar(
+		&params.shouldPrune,
+		pruneFlag,
+		false,
+		"prune historical state trie data before starting the node. "+
+			"Copies only reachable nodes from the latest state root to a new trie database, "+
+			"swaps directories, then starts normally. Original trie is kept as trie_old/",
+	)
+
 	setLegacyFlags(cmd)
 
 	setDevFlags(cmd)
@@ -327,6 +346,16 @@ func isConfigFileSpecified(cmd *cobra.Command) bool {
 func runCommand(cmd *cobra.Command, _ []string) {
 	outputter := command.InitializeOutputter(cmd)
 
+	// Pre-startup prune if --prune flag is set
+	if params.shouldPrune {
+		if err := runPreStartupPrune(outputter); err != nil {
+			outputter.SetError(fmt.Errorf("pre-startup prune failed (original trie untouched): %w", err))
+			outputter.WriteOutput()
+
+			return
+		}
+	}
+
 	config, err := params.generateConfig()
 	if err != nil {
 		outputter.SetError(err)
@@ -341,6 +370,130 @@ func runCommand(cmd *cobra.Command, _ []string) {
 
 		return
 	}
+}
+
+func runPreStartupPrune(outputter command.OutputFormatter) error {
+	dataDir := params.rawConfig.DataDir
+	triePath := filepath.Join(dataDir, "trie")
+	blockchainPath := filepath.Join(dataDir, "blockchain")
+	targetPath := filepath.Join(dataDir, "trie_new")
+
+	// Verify paths exist
+	if _, err := os.Stat(triePath); os.IsNotExist(err) {
+		return fmt.Errorf("trie directory not found at %s", triePath)
+	}
+
+	if _, err := os.Stat(blockchainPath); os.IsNotExist(err) {
+		return fmt.Errorf("blockchain directory not found at %s", blockchainPath)
+	}
+
+	// Don't prune if trie_new already exists (interrupted previous prune)
+	if _, err := os.Stat(targetPath); err == nil {
+		return fmt.Errorf("target %s already exists — previous prune may have been interrupted. "+
+			"Remove it manually before retrying", targetPath)
+	}
+
+	logger := hclog.New(&hclog.LoggerOptions{
+		Name:  "prune",
+		Level: hclog.Info,
+	})
+
+	logger.Info("Starting pre-startup trie prune", "data-dir", dataDir)
+
+	// Resolve state root from blockchain DB
+	chainStorage, err := leveldb2.NewLevelDBStorage(blockchainPath, logger)
+	if err != nil {
+		return fmt.Errorf("failed to open blockchain storage: %w", err)
+	}
+
+	stateRoot, blockNum, err := pruneCmd.GetLatestStateRoot(chainStorage)
+	if err != nil {
+		chainStorage.Close()
+
+		return fmt.Errorf("failed to resolve state root: %w", err)
+	}
+
+	chainStorage.Close()
+
+	logger.Info("State root resolved", "block", blockNum, "root", stateRoot.String())
+
+	// Open source read-only
+	srcDB, err := leveldb.OpenFile(triePath, &opt.Options{ReadOnly: true})
+	if err != nil {
+		return fmt.Errorf("failed to open source trie: %w", err)
+	}
+
+	// Open target for writing
+	dstDB, err := leveldb.OpenFile(targetPath, nil)
+	if err != nil {
+		srcDB.Close()
+
+		return fmt.Errorf("failed to open target trie: %w", err)
+	}
+
+	// Run prune
+	result, err := itrie.PruneTrie(stateRoot, srcDB, dstDB)
+
+	srcDB.Close()
+	dstDB.Close()
+
+	if err != nil {
+		// Clean up failed target
+		os.RemoveAll(targetPath)
+
+		return fmt.Errorf("prune failed: %w", err)
+	}
+
+	logger.Info("Prune completed",
+		"source_keys", result.SourceKeys,
+		"dest_keys", result.DestKeys,
+		"duration", result.Duration.String(),
+		"validated", result.Validated,
+	)
+
+	// Swap directories: trie → trie_old, trie_new → trie
+	trieOldPath := filepath.Join(dataDir, "trie_old")
+
+	// Remove any existing trie_old from a previous prune
+	os.RemoveAll(trieOldPath)
+
+	// Preserve original ownership/permissions
+	srcInfo, err := os.Stat(triePath)
+	if err != nil {
+		return fmt.Errorf("failed to stat source trie: %w", err)
+	}
+
+	if err := os.Rename(triePath, trieOldPath); err != nil {
+		return fmt.Errorf("failed to rename trie → trie_old: %w", err)
+	}
+
+	if err := os.Rename(targetPath, triePath); err != nil {
+		// Rollback: move trie_old back to trie
+		os.Rename(trieOldPath, triePath)
+
+		return fmt.Errorf("failed to rename trie_new → trie: %w", err)
+	}
+
+	// Match permissions of the new trie to the original
+	os.Chmod(triePath, srcInfo.Mode())
+
+	srcSize, _ := itrie.DiskSizeBytes(trieOldPath)
+	dstSize, _ := itrie.DiskSizeBytes(triePath)
+
+	reduction := float64(0)
+	if srcSize > 0 {
+		reduction = float64(srcSize-dstSize) / float64(srcSize) * 100
+	}
+
+	logger.Info("Trie swap complete",
+		"old_size", fmt.Sprintf("%.1f MB", float64(srcSize)/1048576),
+		"new_size", fmt.Sprintf("%.1f MB", float64(dstSize)/1048576),
+		"reduction", fmt.Sprintf("%.1f%%", reduction),
+	)
+
+	logger.Info("Old trie preserved at trie_old/ — delete after confirming stability")
+
+	return nil
 }
 
 func runServerLoop(

--- a/command/server/server.go
+++ b/command/server/server.go
@@ -377,6 +377,32 @@ func runPreStartupPrune(outputter command.OutputFormatter) error {
 	triePath := filepath.Join(dataDir, "trie")
 	blockchainPath := filepath.Join(dataDir, "blockchain")
 	targetPath := filepath.Join(dataDir, "trie_new")
+	trieOldPath := filepath.Join(dataDir, "trie_old")
+
+	logger := hclog.New(&hclog.LoggerOptions{
+		Name:  "prune",
+		Level: hclog.Info,
+	})
+
+	// Crash recovery: detect interrupted swap (SIGKILL between the two renames)
+	// State: trie/ missing, trie_old/ exists → recover by renaming trie_old back
+	_, trieExists := os.Stat(triePath)
+	_, trieOldExists := os.Stat(trieOldPath)
+
+	if os.IsNotExist(trieExists) && trieOldExists == nil {
+		// trie/ gone but trie_old/ present — interrupted swap
+		logger.Warn("Detected interrupted prune swap: trie/ missing but trie_old/ exists. Recovering...")
+
+		if err := os.Rename(trieOldPath, triePath); err != nil {
+			return fmt.Errorf("CRITICAL: auto-recovery failed. Manual fix required: mv %s %s — error: %w",
+				trieOldPath, triePath, err)
+		}
+
+		logger.Info("Recovery complete: trie_old/ renamed back to trie/. Prune will restart.")
+
+		// Clean up any partial trie_new
+		os.RemoveAll(targetPath)
+	}
 
 	// Verify paths exist
 	if _, err := os.Stat(triePath); os.IsNotExist(err) {
@@ -393,11 +419,6 @@ func runPreStartupPrune(outputter command.OutputFormatter) error {
 			"Remove it manually before retrying", targetPath)
 	}
 
-	logger := hclog.New(&hclog.LoggerOptions{
-		Name:  "prune",
-		Level: hclog.Info,
-	})
-
 	logger.Info("Starting pre-startup trie prune", "data-dir", dataDir)
 
 	// Resolve state root from blockchain DB
@@ -413,7 +434,9 @@ func runPreStartupPrune(outputter command.OutputFormatter) error {
 		return fmt.Errorf("failed to resolve state root: %w", err)
 	}
 
-	chainStorage.Close()
+	if err := chainStorage.Close(); err != nil {
+		logger.Warn("Failed to close blockchain storage cleanly", "err", err)
+	}
 
 	logger.Info("State root resolved", "block", blockNum, "root", stateRoot.String())
 
@@ -452,10 +475,13 @@ func runPreStartupPrune(outputter command.OutputFormatter) error {
 	)
 
 	// Swap directories: trie → trie_old, trie_new → trie
-	trieOldPath := filepath.Join(dataDir, "trie_old")
 
 	// Remove any existing trie_old from a previous prune
-	os.RemoveAll(trieOldPath)
+	if _, err := os.Stat(trieOldPath); err == nil {
+		if err := os.RemoveAll(trieOldPath); err != nil {
+			return fmt.Errorf("failed to remove existing trie_old: %w", err)
+		}
+	}
 
 	// Preserve original ownership/permissions
 	srcInfo, err := os.Stat(triePath)
@@ -469,19 +495,30 @@ func runPreStartupPrune(outputter command.OutputFormatter) error {
 
 	if err := os.Rename(targetPath, triePath); err != nil {
 		// Rollback: move trie_old back to trie
-		os.Rename(trieOldPath, triePath)
+		if rbErr := os.Rename(trieOldPath, triePath); rbErr != nil {
+			logger.Error("CRITICAL: rollback failed. Data dir is in an inconsistent state. "+
+				"Manual fix required: mv trie_old trie",
+				"rename_err", err, "rollback_err", rbErr,
+				"trie_old_path", trieOldPath, "trie_path", triePath)
 
-		return fmt.Errorf("failed to rename trie_new → trie: %w", err)
+			return fmt.Errorf("CRITICAL: rename trie_new → trie failed AND rollback failed. "+
+				"Manual fix: mv %s %s — rename error: %w, rollback error: %v",
+				trieOldPath, triePath, err, rbErr)
+		}
+
+		return fmt.Errorf("failed to rename trie_new → trie (rolled back successfully): %w", err)
 	}
 
 	// Match permissions of the new trie to the original
-	os.Chmod(triePath, srcInfo.Mode())
+	if err := os.Chmod(triePath, srcInfo.Mode()); err != nil {
+		logger.Warn("Failed to set permissions on pruned trie", "err", err)
+	}
 
 	srcSize, _ := itrie.DiskSizeBytes(trieOldPath)
 	dstSize, _ := itrie.DiskSizeBytes(triePath)
 
 	reduction := float64(0)
-	if srcSize > 0 {
+	if srcSize > 0 && srcSize > dstSize {
 		reduction = float64(srcSize-dstSize) / float64(srcSize) * 100
 	}
 

--- a/gasprice/gasprice.go
+++ b/gasprice/gasprice.go
@@ -73,6 +73,8 @@ type GasHelper struct {
 	maxPrice *big.Int
 	// lastPrice is the last price returned for maxPriorityFeePerGas
 	lastPrice *big.Int
+	// defaultPrice is the initial price from config, used as fallback when no txs found
+	defaultPrice *big.Int
 	// ignorePrice is the lowest price to take into consideration
 	// when collecting transactions
 	ignorePrice *big.Int
@@ -104,6 +106,7 @@ func NewGasHelper(config *Config, backend Blockchain) (*GasHelper, error) {
 		sampleNumber:       config.SampleNumber,
 		ignorePrice:        config.IgnorePrice,
 		lastPrice:          config.LastPrice,
+		defaultPrice:       new(big.Int).Set(config.LastPrice),
 		maxPrice:           config.MaxPrice,
 		backend:            backend,
 		historyCache:       cache,
@@ -147,7 +150,8 @@ func (g *GasHelper) MaxPriorityFeePerGas() (*big.Int, error) {
 		blockMiner := types.BytesToAddress(block.Header.Miner)
 		signer := crypto.NewSigner(g.backend.Config().Forks.At(block.Number()),
 			uint64(g.backend.Config().ChainID))
-		blockTxPrices := make([]*big.Int, 0)
+
+		blockSamples := 0
 
 		for _, tx := range txSorter.txs {
 			tip := tx.EffectiveGasTip(baseFee)
@@ -163,24 +167,20 @@ func (g *GasHelper) MaxPriorityFeePerGas() (*big.Int, error) {
 			}
 
 			if sender != blockMiner {
-				blockTxPrices = append(blockTxPrices, tip)
+				allPrices = append(allPrices, tip)
+				blockSamples++
 
-				// if sample number of txs from block is reached,
-				// don't process any more txs
-				if len(blockTxPrices) >= int(g.sampleNumber) {
+				// cap samples per block to ensure diversity across blocks
+				if blockSamples >= int(g.sampleNumber) {
 					break
 				}
 			}
 		}
 
-		if len(blockTxPrices) == 0 {
-			// either block is empty or all transactions in block are sent by the miner.
-			// in this case add the latests calculated price for sampling
-			blockTxPrices = append(blockTxPrices, lastPrice)
-		}
-
-		// add the block prices to the slice of all prices
-		allPrices = append(allPrices, blockTxPrices...)
+		// Empty blocks are simply skipped — no synthetic lastPrice injection.
+		// On chains with sparse transactions (e.g. Hydra: ~700 txs/day, 0.4s blocks),
+		// injecting lastPrice into empty blocks causes a ratchet effect where the
+		// estimated gas price can only increase, never decrease.
 
 		return nil
 	}
@@ -198,16 +198,26 @@ func (g *GasHelper) MaxPriorityFeePerGas() (*big.Int, error) {
 		}
 	}
 
-	// at least amount of transactions to get
+	// If not enough transaction samples were collected from the initial window,
+	// scan further back to find more blocks with actual transactions.
 	minNumOfTx := int(g.numOfBlocksToCheck) * 2
-	// collect some more blocks and transactions if not enough transactions were collected
-	for len(allPrices) < minNumOfTx && currentBlock.Number() > 0 {
+	maxExtraBlocks := g.numOfBlocksToCheck * 5 // bounded scan to avoid traversing entire chain
+
+	for extraBlocks := uint64(0); len(allPrices) < minNumOfTx && currentBlock.Number() > 0 && extraBlocks < maxExtraBlocks; extraBlocks++ {
 		if err := collectPrices(currentBlock); err != nil {
 			return nil, err
 		}
+
+		currentBlock, found = g.backend.GetBlockByHash(currentBlock.ParentHash(), true)
+		if !found {
+			break
+		}
 	}
 
-	price := lastPrice
+	// If no real transactions were found in the scanned range, fall back to
+	// the configured initial price (default: 1 Gwei) rather than the previously
+	// cached price. This prevents the oracle from preserving a stale inflated estimate.
+	price := new(big.Int).Set(g.defaultPrice)
 
 	if len(allPrices) > 0 {
 		// sort prices from lowest to highest

--- a/gasprice/gasprice_test.go
+++ b/gasprice/gasprice_test.go
@@ -168,6 +168,88 @@ func TestGasHelper_MaxPriorityFeePerGas(t *testing.T) {
 	}
 }
 
+// TestGasHelper_NoPriceRatchetOnEmptyBlocks verifies that the gas price oracle
+// does not ratchet upward when most blocks are empty (sparse-transaction chains).
+// This was the root cause of gas price drift on Hydra mainnet.
+func TestGasHelper_NoPriceRatchetOnEmptyBlocks(t *testing.T) {
+	t.Parallel()
+
+	// Create 50 blocks, put 1 transaction with a high tip only in block 25
+	backend := createTestBlocks(t, 50)
+	senderKey, _ := tests.GenerateKeyAndAddr(t)
+
+	block25 := backend.blocksByNumber[25]
+	signer := crypto.NewSigner(backend.Config().Forks.At(block25.Number()),
+		uint64(backend.Config().ChainID))
+
+	highTipTx := &types.Transaction{
+		From:      types.ZeroAddress,
+		Value:     big.NewInt(0),
+		To:        &types.ZeroAddress,
+		Type:      types.DynamicFeeTx,
+		GasTipCap: ethgo.Gwei(100), // 100 Gwei tip - artificially high
+		GasFeeCap: ethgo.Gwei(200),
+	}
+	highTipTx, err := signer.SignTx(highTipTx, senderKey)
+	require.NoError(t, err)
+	block25.Transactions = []*types.Transaction{highTipTx}
+
+	// Use a local config to avoid the pre-existing data race where other parallel
+	// tests mutate DefaultGasHelperConfig.LastPrice in-place via big.Int.Mul()
+	testConfig := &Config{
+		NumOfBlocksToCheck: 20,
+		PricePercentile:    60,
+		SampleNumber:       3,
+		MaxPrice:           ethgo.Gwei(500),
+		LastPrice:          ethgo.Gwei(1),
+		IgnorePrice:        big.NewInt(2),
+	}
+
+	gasHelper, err := NewGasHelper(testConfig, backend)
+	require.NoError(t, err)
+
+	// First call — should pick up the high tip tx
+	price1, err := gasHelper.MaxPriorityFeePerGas()
+	require.NoError(t, err)
+
+	// Now simulate time passing: update header to a new block with no txs
+	// The price should NOT keep the high value from the old tx
+	// Add enough empty blocks that the scan window (20 initial + 100 extended = 120)
+	// cannot reach block 25 with the high-tip tx
+	currentTop := backend.blocksByNumber[50]
+	for i := 51; i <= 200; i++ {
+		block := &types.Block{
+			Header: &types.Header{
+				Number:     uint64(i),
+				Hash:       types.BytesToHash([]byte(fmt.Sprintf("Block %d", i))),
+				Miner:      types.ZeroAddress.Bytes(),
+				ParentHash: currentTop.Hash(),
+				BaseFee:    chain.GenesisBaseFee,
+			},
+		}
+		backend.blocksByNumber[block.Number()] = block
+		backend.blocks[block.Hash()] = block
+		currentTop = block
+	}
+
+	// Reset mock to return new header
+	backend.ExpectedCalls = nil
+	backend.On("Header").Return(currentTop.Header)
+
+	// Second call — scanning the latest 20+100 blocks which are all empty
+	price2, err := gasHelper.MaxPriorityFeePerGas()
+	require.NoError(t, err)
+
+	// The price should fall back to the default (1 Gwei), not stay at 100 Gwei
+	// With the old buggy code, empty blocks injected lastPrice (100 Gwei),
+	// so price2 would equal price1. With the fix, it returns the default.
+	require.True(t, price2.Cmp(price1) < 0,
+		"gas price should decrease when recent blocks are empty, got price1=%s price2=%s", price1, price2)
+	// Compare against a fresh value, not the global which other tests mutate in-place
+	require.Equal(t, ethgo.Gwei(1), price2,
+		"gas price should return to default when no recent transactions exist")
+}
+
 func createTestBlocks(t *testing.T, numOfBlocks int) *backendMock {
 	t.Helper()
 

--- a/state/immutable-trie/prune.go
+++ b/state/immutable-trie/prune.go
@@ -30,6 +30,7 @@ type flushingBatch struct {
 	count         int
 	total         int64
 	flushInterval int
+	err           error
 }
 
 func newFlushingBatch(storage Storage, flushInterval int) *flushingBatch {
@@ -41,19 +42,31 @@ func newFlushingBatch(storage Storage, flushInterval int) *flushingBatch {
 }
 
 func (f *flushingBatch) Put(k, v []byte) {
+	if f.err != nil {
+		return
+	}
+
 	f.batch.Put(k, v)
 	f.count++
 	f.total++
 
 	if f.count >= f.flushInterval {
-		// Flush is best-effort during traversal; final flush is checked
-		f.batch.Write() //nolint:errcheck
+		if err := f.batch.Write(); err != nil {
+			f.err = fmt.Errorf("flush to disk failed after %d entries: %w", f.total, err)
+
+			return
+		}
+
 		f.batch = f.storage.Batch()
 		f.count = 0
 	}
 }
 
 func (f *flushingBatch) Write() error {
+	if f.err != nil {
+		return f.err
+	}
+
 	if f.count > 0 {
 		return f.batch.Write()
 	}

--- a/state/immutable-trie/prune.go
+++ b/state/immutable-trie/prune.go
@@ -1,0 +1,57 @@
+package itrie
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/0xPolygon/polygon-edge/types"
+	"github.com/syndtr/goleveldb/leveldb"
+)
+
+// PruneResult holds the outcome of a trie pruning operation.
+type PruneResult struct {
+	StateRoot  types.Hash
+	BlockNum   uint64
+	SourceKeys int64
+	DestKeys   int64
+	SourceSize int64
+	DestSize   int64
+	Duration   time.Duration
+	Validated  bool
+}
+
+// PruneTrie copies all trie nodes reachable from stateRoot in srcDB to dstDB,
+// then validates the copy by running HashChecker. Source DB is not modified.
+func PruneTrie(stateRoot types.Hash, srcDB *leveldb.DB, dstDB *leveldb.DB) (*PruneResult, error) {
+	start := time.Now()
+
+	srcKV := NewKV(srcDB)
+	dstKV := NewKV(dstDB)
+
+	// Copy all reachable nodes from the state root
+	if err := CopyTrie(stateRoot.Bytes(), srcKV, dstKV, nil, false); err != nil {
+		return nil, fmt.Errorf("CopyTrie failed: %w", err)
+	}
+
+	// Validate the copy produces the same state root
+	checkedRoot, err := HashChecker(stateRoot.Bytes(), dstKV)
+	if err != nil {
+		return nil, fmt.Errorf("HashChecker failed on destination: %w", err)
+	}
+
+	if checkedRoot != stateRoot {
+		return nil, fmt.Errorf("state root mismatch after copy: expected %s, got %s", stateRoot, checkedRoot)
+	}
+
+	// Collect metrics
+	srcKeys, _ := KeyCount(srcDB)
+	dstKeys, _ := KeyCount(dstDB)
+
+	return &PruneResult{
+		StateRoot:  stateRoot,
+		SourceKeys: srcKeys,
+		DestKeys:   dstKeys,
+		Duration:   time.Since(start),
+		Validated:  true,
+	}, nil
+}

--- a/state/immutable-trie/prune.go
+++ b/state/immutable-trie/prune.go
@@ -8,6 +8,8 @@ import (
 	"github.com/syndtr/goleveldb/leveldb"
 )
 
+const defaultFlushInterval = 50000
+
 // PruneResult holds the outcome of a trie pruning operation.
 type PruneResult struct {
 	StateRoot  types.Hash
@@ -20,17 +22,69 @@ type PruneResult struct {
 	Validated  bool
 }
 
+// flushingBatch wraps a Storage and flushes to LevelDB every flushInterval puts,
+// preventing unbounded memory growth when copying large tries.
+type flushingBatch struct {
+	storage       Storage
+	batch         Batch
+	count         int
+	total         int64
+	flushInterval int
+}
+
+func newFlushingBatch(storage Storage, flushInterval int) *flushingBatch {
+	return &flushingBatch{
+		storage:       storage,
+		batch:         storage.Batch(),
+		flushInterval: flushInterval,
+	}
+}
+
+func (f *flushingBatch) Put(k, v []byte) {
+	f.batch.Put(k, v)
+	f.count++
+	f.total++
+
+	if f.count >= f.flushInterval {
+		// Flush is best-effort during traversal; final flush is checked
+		f.batch.Write() //nolint:errcheck
+		f.batch = f.storage.Batch()
+		f.count = 0
+	}
+}
+
+func (f *flushingBatch) Write() error {
+	if f.count > 0 {
+		return f.batch.Write()
+	}
+
+	return nil
+}
+
+// CopyTrieStreaming is like CopyTrie but flushes to disk every flushInterval nodes,
+// keeping memory usage bounded regardless of trie size.
+func CopyTrieStreaming(nodeHash []byte, storage Storage, newStorage Storage, flushInterval int) error {
+	fb := newFlushingBatch(newStorage, flushInterval)
+
+	if err := copyTrieHash(nodeHash, storage, fb, nil, false); err != nil {
+		return err
+	}
+
+	return fb.Write()
+}
+
 // PruneTrie copies all trie nodes reachable from stateRoot in srcDB to dstDB,
 // then validates the copy by running HashChecker. Source DB is not modified.
+// Uses streaming writes to keep memory bounded on large tries.
 func PruneTrie(stateRoot types.Hash, srcDB *leveldb.DB, dstDB *leveldb.DB) (*PruneResult, error) {
 	start := time.Now()
 
 	srcKV := NewKV(srcDB)
 	dstKV := NewKV(dstDB)
 
-	// Copy all reachable nodes from the state root
-	if err := CopyTrie(stateRoot.Bytes(), srcKV, dstKV, nil, false); err != nil {
-		return nil, fmt.Errorf("CopyTrie failed: %w", err)
+	// Copy all reachable nodes, flushing every 50k entries to keep memory bounded
+	if err := CopyTrieStreaming(stateRoot.Bytes(), srcKV, dstKV, defaultFlushInterval); err != nil {
+		return nil, fmt.Errorf("CopyTrieStreaming failed: %w", err)
 	}
 
 	// Validate the copy produces the same state root

--- a/state/immutable-trie/prune_test.go
+++ b/state/immutable-trie/prune_test.go
@@ -80,6 +80,35 @@ func TestPruneTrie_PropertyBased(t *testing.T) {
 	})
 }
 
+func TestFlushingBatch_FlushesAtInterval(t *testing.T) {
+	t.Parallel()
+
+	db := newMemLevelDB(t)
+	kv := NewKV(db)
+
+	fb := newFlushingBatch(kv, 10)
+
+	// Write 25 entries — should trigger 2 auto-flushes (at 10 and 20), leaving 5 pending
+	for i := 0; i < 25; i++ {
+		key := make([]byte, 32)
+		key[0] = byte(i)
+		fb.Put(key, []byte("value"))
+	}
+
+	// Before final Write, 20 entries should already be in DB (from 2 flushes)
+	count, err := KeyCount(db)
+	require.NoError(t, err)
+	assert.Equal(t, int64(20), count)
+
+	// Final Write flushes remaining 5
+	require.NoError(t, fb.Write())
+
+	count, err = KeyCount(db)
+	require.NoError(t, err)
+	assert.Equal(t, int64(25), count)
+	assert.Equal(t, int64(25), fb.total)
+}
+
 func TestPruneTrie_WithContractCode(t *testing.T) {
 	t.Parallel()
 

--- a/state/immutable-trie/prune_test.go
+++ b/state/immutable-trie/prune_test.go
@@ -109,6 +109,65 @@ func TestFlushingBatch_FlushesAtInterval(t *testing.T) {
 	assert.Equal(t, int64(25), fb.total)
 }
 
+func TestFlushingBatch_ExactMultiple(t *testing.T) {
+	t.Parallel()
+
+	db := newMemLevelDB(t)
+	kv := NewKV(db)
+
+	fb := newFlushingBatch(kv, 10)
+
+	for i := 0; i < 20; i++ {
+		key := make([]byte, 32)
+		key[0] = byte(i)
+		fb.Put(key, []byte("value"))
+	}
+
+	count, err := KeyCount(db)
+	require.NoError(t, err)
+	assert.Equal(t, int64(20), count)
+
+	require.NoError(t, fb.Write())
+
+	count, err = KeyCount(db)
+	require.NoError(t, err)
+	assert.Equal(t, int64(20), count)
+}
+
+func TestFlushingBatch_ErrorStopsWrites(t *testing.T) {
+	t.Parallel()
+
+	db := newMemLevelDB(t)
+	kv := NewKV(db)
+
+	fb := newFlushingBatch(kv, 5)
+
+	for i := 0; i < 5; i++ {
+		key := make([]byte, 32)
+		key[0] = byte(i)
+		fb.Put(key, []byte("value"))
+	}
+
+	require.NoError(t, fb.err, "first flush should succeed")
+
+	db.Close()
+
+	for i := 5; i < 10; i++ {
+		key := make([]byte, 32)
+		key[0] = byte(i)
+		fb.Put(key, []byte("value"))
+	}
+
+	require.Error(t, fb.err, "flush after DB close should fail")
+
+	fb.Put(make([]byte, 32), []byte("ignored"))
+	assert.Equal(t, int64(10), fb.total, "total should stop incrementing after error")
+
+	err := fb.Write()
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "flush to disk failed")
+}
+
 func TestPruneTrie_WithContractCode(t *testing.T) {
 	t.Parallel()
 

--- a/state/immutable-trie/prune_test.go
+++ b/state/immutable-trie/prune_test.go
@@ -1,0 +1,197 @@
+package itrie
+
+import (
+	"testing"
+
+	"math/big"
+
+	"github.com/0xPolygon/polygon-edge/state"
+	"github.com/0xPolygon/polygon-edge/types"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/syndtr/goleveldb/leveldb"
+	ldbstorage "github.com/syndtr/goleveldb/leveldb/storage"
+	"pgregory.net/rapid"
+)
+
+func newMemLevelDBPair(t *testing.T) (*leveldb.DB, *leveldb.DB) {
+	t.Helper()
+
+	srcDB, err := leveldb.Open(ldbstorage.NewMemStorage(), nil)
+	require.NoError(t, err)
+
+	dstDB, err := leveldb.Open(ldbstorage.NewMemStorage(), nil)
+	require.NoError(t, err)
+
+	t.Cleanup(func() {
+		srcDB.Close()
+		dstDB.Close()
+	})
+
+	return srcDB, dstDB
+}
+
+func TestPruneTrie_PropertyBased(t *testing.T) {
+	t.Parallel()
+
+	rapid.Check(t, func(tt *rapid.T) {
+		srcDB, dstDB := newMemLevelDBPair(t)
+		kv := NewKV(srcDB)
+
+		state := NewState(kv)
+		trie := state.newTrie()
+		tx := trie.Txn(kv)
+
+		// Insert random trie entries
+		n := rapid.IntRange(1, 200).Draw(tt, "n")
+		for i := 0; i < n; i++ {
+			key := rapid.SliceOfN(rapid.Byte(), 32, 32).Draw(tt, "key")
+			value := rapid.SliceOfN(rapid.Byte(), 10, 80).Draw(tt, "value")
+			tx.Insert(key, value)
+		}
+
+		tx.Commit()
+		stateRoot := trie.Hash()
+
+		// Add garbage keys (simulating old block trie nodes)
+		garbageCount := rapid.IntRange(10, 100).Draw(tt, "garbage")
+		for i := 0; i < garbageCount; i++ {
+			garbageKey := rapid.SliceOfN(rapid.Byte(), 32, 32).Draw(tt, "garbageKey")
+			garbageVal := rapid.SliceOfN(rapid.Byte(), 20, 100).Draw(tt, "garbageVal")
+			_ = srcDB.Put(garbageKey, garbageVal, nil)
+		}
+
+		srcKeys, err := KeyCount(srcDB)
+		require.NoError(t, err)
+
+		// Prune
+		result, err := PruneTrie(types.BytesToHash(stateRoot.Bytes()), srcDB, dstDB)
+		require.NoError(t, err)
+		require.True(t, result.Validated)
+
+		// Destination should have fewer keys than source (garbage removed)
+		assert.Less(t, result.DestKeys, srcKeys)
+		assert.Greater(t, result.DestKeys, int64(0))
+
+		// HashChecker on destination should match
+		checkedRoot, err := HashChecker(stateRoot.Bytes(), NewKV(dstDB))
+		require.NoError(t, err)
+		assert.Equal(t, types.BytesToHash(stateRoot.Bytes()), checkedRoot)
+	})
+}
+
+func TestPruneTrie_WithContractCode(t *testing.T) {
+	t.Parallel()
+
+	srcDB, dstDB := newMemLevelDBPair(t)
+	kv := NewKV(srcDB)
+
+	// Store contract code directly in the source DB with the code prefix
+	codeHash := types.StringToHash("0xdeadbeef00000000000000000000000000000000000000000000000000000001")
+	codeBytes := []byte{0x60, 0x80, 0x60, 0x40, 0x52}
+	require.NoError(t, kv.SetCode(codeHash, codeBytes))
+
+	// Verify code is in source
+	code, ok := kv.GetCode(codeHash)
+	require.True(t, ok)
+	require.Equal(t, codeBytes, code)
+
+	// CopyTrie only copies code when it encounters accounts with CodeHash in the trie.
+	// For a standalone code copy test, verify PruneTrie copies code-prefix keys.
+	// Since CopyTrie walks the trie and copies code it finds via account references,
+	// code that isn't referenced by any account in the trie won't be copied.
+	// This is correct behavior — orphaned code should be pruned too.
+
+	// Create a minimal trie
+	state := NewState(kv)
+	trie := state.newTrie()
+	tx := trie.Txn(kv)
+	tx.Insert(make([]byte, 32), []byte("account-data"))
+	tx.Commit()
+	stateRoot := trie.Hash()
+
+	result, err := PruneTrie(types.BytesToHash(stateRoot.Bytes()), srcDB, dstDB)
+	require.NoError(t, err)
+	require.True(t, result.Validated)
+
+	// Unreferenced code should NOT be in destination (correctly pruned)
+	dstKV := NewKV(dstDB)
+	_, ok = dstKV.GetCode(codeHash)
+	assert.False(t, ok, "orphaned code should be pruned")
+}
+
+func TestPruneTrie_InvalidStateRoot(t *testing.T) {
+	t.Parallel()
+
+	srcDB, dstDB := newMemLevelDBPair(t)
+
+	badRoot := types.StringToHash("0xbadbadbadbadbadbadbadbadbadbadbadbadbadbadbadbadbadbadbadbadbad00")
+
+	_, err := PruneTrie(badRoot, srcDB, dstDB)
+	assert.Error(t, err)
+}
+
+func TestPruneTrie_MultipleBlocks_OnlyLatestRetained(t *testing.T) {
+	t.Parallel()
+
+	srcDB, dstDB := newMemLevelDBPair(t)
+	kv := NewKV(srcDB)
+	st := NewState(kv)
+
+	// Block 1: commit accounts via Snapshot.Commit (production path, writes to LevelDB)
+	snap1 := st.NewSnapshot()
+
+	objs1 := make([]*state.Object, 5)
+	for i := 0; i < 5; i++ {
+		addr := types.Address{}
+		addr[0] = byte(i + 1)
+
+		objs1[i] = &state.Object{
+			Address:  addr,
+			CodeHash: types.EmptyCodeHash,
+			Balance:  big.NewInt(int64(1000 * (i + 1))),
+			Root:     types.EmptyRootHash,
+			Nonce:    uint64(i),
+		}
+	}
+
+	snap2, root1, err := snap1.Commit(objs1)
+	require.NoError(t, err)
+	require.NotEqual(t, types.EmptyRootHash.Bytes(), root1)
+
+	keysAfterBlock1, err := KeyCount(srcDB)
+	require.NoError(t, err)
+	require.Greater(t, keysAfterBlock1, int64(0))
+
+	// Block 2: modify balances → different state root, more nodes written
+	objs2 := make([]*state.Object, 5)
+	for i := 0; i < 5; i++ {
+		addr := types.Address{}
+		addr[0] = byte(i + 1)
+
+		objs2[i] = &state.Object{
+			Address:  addr,
+			CodeHash: types.EmptyCodeHash,
+			Balance:  big.NewInt(int64(9999 * (i + 1))),
+			Root:     types.EmptyRootHash,
+			Nonce:    uint64(i + 100),
+		}
+	}
+
+	_, root2, err := snap2.Commit(objs2)
+	require.NoError(t, err)
+	require.NotEqual(t, root1, root2, "two blocks with different balances must have different roots")
+
+	srcKeys, err := KeyCount(srcDB)
+	require.NoError(t, err)
+	require.Greater(t, srcKeys, keysAfterBlock1, "block 2 should add more keys")
+
+	// Prune using block 2's root
+	result, err := PruneTrie(types.BytesToHash(root2), srcDB, dstDB)
+	require.NoError(t, err)
+	require.True(t, result.Validated)
+
+	// Destination should have fewer keys (block 1's orphaned nodes pruned)
+	assert.Less(t, result.DestKeys, srcKeys)
+	assert.Greater(t, result.DestKeys, int64(0))
+}

--- a/state/immutable-trie/storage_stats.go
+++ b/state/immutable-trie/storage_stats.go
@@ -1,0 +1,62 @@
+package itrie
+
+import (
+	"os"
+	"path/filepath"
+
+	"github.com/syndtr/goleveldb/leveldb"
+	"github.com/syndtr/goleveldb/leveldb/util"
+)
+
+// KeyCount returns the total number of keys in the LevelDB database.
+func KeyCount(db *leveldb.DB) (int64, error) {
+	iter := db.NewIterator(nil, nil)
+	defer iter.Release()
+
+	var count int64
+	for iter.Next() {
+		count++
+	}
+
+	if err := iter.Error(); err != nil {
+		return 0, err
+	}
+
+	return count, nil
+}
+
+// KeyCountWithPrefix returns the number of keys with a given prefix.
+func KeyCountWithPrefix(db *leveldb.DB, prefix []byte) (int64, error) {
+	iter := db.NewIterator(util.BytesPrefix(prefix), nil)
+	defer iter.Release()
+
+	var count int64
+	for iter.Next() {
+		count++
+	}
+
+	if err := iter.Error(); err != nil {
+		return 0, err
+	}
+
+	return count, nil
+}
+
+// DiskSizeBytes returns the total size of all files in the LevelDB directory.
+func DiskSizeBytes(path string) (int64, error) {
+	var total int64
+
+	err := filepath.Walk(path, func(_ string, info os.FileInfo, err error) error {
+		if err != nil {
+			return err
+		}
+
+		if !info.IsDir() {
+			total += info.Size()
+		}
+
+		return nil
+	})
+
+	return total, err
+}

--- a/state/immutable-trie/storage_stats_test.go
+++ b/state/immutable-trie/storage_stats_test.go
@@ -1,0 +1,110 @@
+package itrie
+
+import (
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/syndtr/goleveldb/leveldb"
+	ldbstorage "github.com/syndtr/goleveldb/leveldb/storage"
+)
+
+func newMemLevelDB(t *testing.T) *leveldb.DB {
+	t.Helper()
+
+	db, err := leveldb.Open(ldbstorage.NewMemStorage(), nil)
+	require.NoError(t, err)
+
+	t.Cleanup(func() { db.Close() })
+
+	return db
+}
+
+func TestKeyCount_EmptyDB(t *testing.T) {
+	t.Parallel()
+
+	db := newMemLevelDB(t)
+
+	count, err := KeyCount(db)
+	require.NoError(t, err)
+	assert.Equal(t, int64(0), count)
+}
+
+func TestKeyCount_AfterInserts(t *testing.T) {
+	t.Parallel()
+
+	db := newMemLevelDB(t)
+
+	for i := 0; i < 50; i++ {
+		key := []byte{byte(i), byte(i >> 8)}
+		require.NoError(t, db.Put(key, []byte("value"), nil))
+	}
+
+	count, err := KeyCount(db)
+	require.NoError(t, err)
+	assert.Equal(t, int64(50), count)
+}
+
+func TestKeyCount_WithCodePrefixKeys(t *testing.T) {
+	t.Parallel()
+
+	db := newMemLevelDB(t)
+
+	// Add 10 trie node keys (32-byte hashes)
+	for i := 0; i < 10; i++ {
+		key := make([]byte, 32)
+		key[0] = byte(i)
+		require.NoError(t, db.Put(key, []byte("node-data"), nil))
+	}
+
+	// Add 5 code keys (prefixed with "code")
+	for i := 0; i < 5; i++ {
+		key := make([]byte, 36)
+		copy(key, codePrefix)
+		key[4] = byte(i)
+		require.NoError(t, db.Put(key, []byte("bytecode"), nil))
+	}
+
+	// Total should be 15
+	count, err := KeyCount(db)
+	require.NoError(t, err)
+	assert.Equal(t, int64(15), count)
+
+	// Code-prefix count should be 5
+	codeCount, err := KeyCountWithPrefix(db, codePrefix)
+	require.NoError(t, err)
+	assert.Equal(t, int64(5), codeCount)
+}
+
+func TestDiskSizeBytes(t *testing.T) {
+	t.Parallel()
+
+	dir, err := os.MkdirTemp("", "storage_stats_test")
+	require.NoError(t, err)
+
+	t.Cleanup(func() { os.RemoveAll(dir) })
+
+	db, err := leveldb.OpenFile(dir, nil)
+	require.NoError(t, err)
+
+	// Insert some data to create files on disk
+	for i := 0; i < 100; i++ {
+		key := make([]byte, 32)
+		key[0] = byte(i)
+		require.NoError(t, db.Put(key, make([]byte, 256), nil))
+	}
+
+	require.NoError(t, db.Close())
+
+	size, err := DiskSizeBytes(dir)
+	require.NoError(t, err)
+	assert.Greater(t, size, int64(0))
+}
+
+func TestDiskSizeBytes_NonexistentPath(t *testing.T) {
+	t.Parallel()
+
+	_, err := DiskSizeBytes("/nonexistent/path/xyz")
+	assert.Error(t, err)
+}


### PR DESCRIPTION
## Summary

Promotes all testnet-validated changes to mainnet production.

### Gas Price Oracle Fix (#135)
- Fix `eth_gasPrice` ratcheting from 1 Gwei to 300+ Gwei on sparse-transaction chains
- Empty blocks no longer inject synthetic `lastPrice` samples
- Fix infinite-loop in extended scan (currentBlock never advanced)
- Fall back to default 1 Gwei when no real transactions in scan window
- **Validated**: unit tests (18 pass), e2e devnet, deployed to testnet (all 5 nodes, running since 2026-04-21)

### Trie Pruning Feature (#133)
- `prune-trie` CLI command for offline state trie pruning
- `--prune` server flag for pre-startup pruning
- Hardened swap logic with crash recovery
- Streaming writes to prevent OOM on large tries
- Flush error propagation
- golangci-lint fixes

## Commits (8)
- `ba6265be` fix(gasprice): prevent gas price oracle from ratcheting upward (#135)
- `f87415b8` fix(prune): propagate flush errors in flushingBatch
- `2fa8ee26` fix(prune): use streaming writes to prevent OOM on large tries
- `b30a1245` Merge PR #133 (feature/trie-pruning)
- `6b52d580` style: fix golangci-lint issues
- `1d17c58f` fix(server): harden --prune swap logic with crash recovery
- `ba5699ad` feat(server): add --prune flag for pre-startup trie pruning
- `a1e92074` feat(cli): add prune-trie command for offline state trie pruning

## Deployment Plan
1. ~~Local devnet~~ — gas price fix validated
2. ~~Testnet~~ — all changes deployed 2026-04-21, running stable
3. Mainnet RPC nodes (RPC-1/2/3) — rolling deploy
4. Mainnet validators (Validator-1/2) — rolling deploy

## Test Plan
- [x] Unit tests pass (18/18 gasprice, full suite green)
- [x] E2e devnet: gas price ratchet confirmed on buggy code, recovery confirmed on fixed code
- [x] Testnet: 5 validators + RPC running stable since deploy
- [ ] Mainnet RPC: rolling deploy, verify gas price stability
- [ ] Mainnet validators: rolling deploy after RPC verification

🤖 Generated with [Claude Code](https://claude.com/claude-code)