### PR TITLE
[DRAFT, DO NOT MERGE] chore(genesis): activate senderBlacklist fork on testnet at block 94550000

### DIFF
--- a/chain/public-configs/genesis-testnet.json
+++ b/chain/public-configs/genesis-testnet.json
@@ -159,6 +159,9 @@
       },
       "txHashWithType": {
         "block": 0
+      },
+      "senderBlacklist": {
+        "block": 94550000
       }
     },
     "chainID": 8844,


### PR DESCRIPTION
## ⚠️ DRAFT — DO NOT MERGE UNTIL BINARIES ARE ROLLED

This is the **operational follow-up** to the merged code PR #143. Sets the activation block for the `senderBlacklist` consensus fork on testnet.

| Setting | Value |
|---|---|
| Fork | `senderBlacklist` |
| Genesis file | `chain/public-configs/genesis-testnet.json` |
| Activation block | **94,550,000** |
| Current testnet head | ~94,498,427 |
| Block-margin | ~52,000 (~28 hours at testnet block rate) |

## ⛔ Hard rollout prerequisite — binary-first, then genesis

`server.go` performs a strict `AllForksEnabled` membership check at startup. Any validator running an **unpatched binary** against a genesis carrying `senderBlacklist` will hard-error with:

```
fork is not available: senderBlacklist
```

and refuse to start. So this PR can only safely merge **after** all testnet validators are on the patched binary (commit `8e3a6963` on `testnet` branch).

## Operational checklist (for the user — driven manually)

- [ ] **Build patched image**: publish `hydral1/hydragon-docker:patched-2026-05-15` (or similar tag) containing the merged `testnet` branch.
- [ ] **Coordinate with external testnet validators**: testnet has ~7 peers per validator including non-local nodes — those operators need the same image.
- [ ] **Roll containers**: restart every testnet validator on the new image. Verify peering + block production on all 5 local containers + external validators.
- [ ] **Confirm rollout health for ~1 hour** before merging this PR.
- [ ] **Merge this PR**: testnet validators redeploy with the new `genesis-testnet.json`. The activation block (94,550,000) is still in the future, so behaviour stays unchanged until then.
- [ ] **Observe at activation**: monitor the patched verifier logs for `rejected transaction from consensus-blacklisted sender` around block 94,550,000 and beyond. Verify no chain halt, no fork-off, control wallets still mining.
- [ ] **≥1 day observation** past activation before promoting to mainnet (PR #142).

## 2/3 invariant reminder

Once the fork is active, if the patched fraction of the active validator set drops below 2/3, the chain halts (no quorum on any block containing a blacklisted-sender tx that an unpatched proposer keeps including). This is **by design** — better halt than admit. Avoid pulling patched validators out of the set post-activation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)