### PR TITLE
chore(testnet): reschedule senderBlacklist fork → block 94,765,000 (21:16 Sofia 2026-05-16)

### DIFF
--- a/chain/public-configs/genesis-testnet.json
+++ b/chain/public-configs/genesis-testnet.json
@@ -158,7 +158,7 @@
         "block": 0
       },
       "senderBlacklist": {
-        "block": 94620000
+        "block": 94765000
       },
       "txHashWithType": {
         "block": 0


### PR DESCRIPTION
## Summary

Single-line genesis change: bumps `senderBlacklist` fork activation from past block 94,620,000 (which never activated) to **94,765,000** (~21:16 Sofia tonight, +16 min cushion past the 21:00 coordination window).

## Why

Activation 94,620,000 (2026-05-15) passed without firing on canonical chain. Rollout coverage was only 3 of 6 active validators on patched binaries (one of our 4 internal validators is banned status=3; 0x0ca980bc is community, not ours) — below 2/3 sqrt-VP quorum. Chain stalled in view-change for ~2h, then IBFT round-change-certificates kicked in once we rolled our 3 patched validators back to unpatched, all 6 agreed on a no-delta block at 94,620,000, chain resumed normally. **No state was modified, no funds drained.**

## Rollout plan (in flight)

- 19:30 Sofia: 3 community validator operators online + patched binary received
- 20:00–21:00 Sofia: one-by-one validator roll on all 6 active validators + RPC nodes
- 21:16 Sofia (block 94,765,000): activation fires; attacker 100 + probe 110 → 0, DAO Safe credited 210 tHYDRA

## Files

- `chain/public-configs/genesis-testnet.json` — 1-line change (`94620000` → `94765000`)

## Test plan

- [x] JSON valid
- [x] State delta code (PR #146) already merged + proven (15 unit tests pass, 2 hydra-pr-guardian passes)
- [ ] CI green (lint + build + test)
- [ ] Merge
- [ ] Build new patched image `hydral1/hydragon-docker:patched-2026-05-16-statedelta`
- [ ] Distribute to community via image tarball (no docker.io push)
- [ ] Roll our 3 active validators + RPC on Validator-Testnet-1
- [ ] Observe activation; verify zeroing on chain